### PR TITLE
Fix install on macOS 10.12.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
           perl: 5.22
         - os: osx
           language: generic
+    exclude:
+        - language: ruby # no idea why this is needed
     allow_failures:
         - os: osx
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ addons:
     postgresql: "9.3"
     hosts:
         - mediacloud.local
-os:
-  - linux
-  - osx
 language: generic
 matrix:
     include:
@@ -14,9 +11,6 @@ matrix:
           language: perl
           perl: 5.22
         - os: osx
-          language: generic
-    exclude:
-        - os: linux
           language: generic
     allow_failures:
         - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
 os:
   - linux
   - osx
+langauge: generic
 matrix:
     include:
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,17 @@ addons:
     postgresql: "9.3"
     hosts:
         - mediacloud.local
+os:
+  - linux
+  - osx
 matrix:
     include:
         - os: linux
-          perl: "5.22"
+          language: perl
+          perl: 5.22
         - os: osx
           language: generic
-      allow_failures:
+    allow_failures:
         - os: osx
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
-language: perl
 # Installing up-to-date Erlang requires root
-os:
-  - linux
-  - osx
 sudo: true
-perl:
-    - "5.22"
 addons:
     postgresql: "9.3"
     hosts:
         - mediacloud.local
 matrix:
-  allow_failures:
-    - os: osx
+    include:
+        - os: linux
+          perl: "5.22"
+        - os: osx
+          language: generic
+      allow_failures:
+        - os: osx
 cache:
     directories:
         # Carton dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: perl
 # Installing up-to-date Erlang requires root
+os:
+  - linux
+  - osx
 sudo: true
 perl:
     - "5.22"
@@ -7,6 +10,9 @@ addons:
     postgresql: "9.3"
     hosts:
         - mediacloud.local
+matrix:
+  allow_failures:
+    - os: osx
 cache:
     directories:
         # Carton dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
 os:
   - linux
   - osx
-langauge: generic
+language: generic
 matrix:
     include:
         - os: linux
@@ -16,7 +16,8 @@ matrix:
         - os: osx
           language: generic
     exclude:
-        - language: ruby # no idea why this is needed
+        - os: linux
+          language: generic
     allow_failures:
         - os: osx
 cache:

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1210,6 +1210,13 @@ DISTRIBUTIONS
       Module::Build 0.38
       URI::Escape 0
       perl 5.008001
+  Cpanel-JSON-XS-3.0231
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-3.0231.tar.gz
+    provides:
+      Cpanel::JSON::XS 3.0231
+    requirements:
+      ExtUtils::MakeMaker 0
+      Pod::Text 2.08
   Crypt-Random-Seed-0.03
     pathname: D/DA/DANAJ/Crypt-Random-Seed-0.03.tar.gz
     provides:
@@ -2703,7 +2710,7 @@ DISTRIBUTIONS
       Encode::HanConvert::Perl 0.06
     requirements:
       Encode 1.41
-      ExtUtils::MakeMaker 7.1001
+      ExtUtils::MakeMaker 7.1002
   Encode-Locale-1.05
     pathname: G/GA/GAAS/Encode-Locale-1.05.tar.gz
     provides:
@@ -3787,7 +3794,6 @@ DISTRIBUTIONS
       IO::Socket::SSL::Utils 2.014
     requirements:
       ExtUtils::MakeMaker 0
-      Mozilla::CA 0
       Net::SSLeay 1.46
       Scalar::Util 0
   IO-String-1.08
@@ -3861,19 +3867,6 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       File::Spec 0.8
       perl 5.008001
-  Inline-Python-0.52
-    pathname: N/NI/NINE/Inline-Python-0.52.tar.gz
-    provides:
-      Inline::Python 0.52
-      Inline::Python::Boolean 0.52
-      Inline::Python::Function 0.52
-      Inline::Python::Object 0.52
-      Inline::Python::Object::Data 0.52
-    requirements:
-      Data::Dumper 0
-      Digest::MD5 2.5
-      ExtUtils::MakeMaker 0
-      Inline 0.46
   JSON-2.90
     pathname: M/MA/MAKAMAKA/JSON-2.90.tar.gz
     provides:
@@ -3889,6 +3882,7 @@ DISTRIBUTIONS
       JSON::MaybeXS 1.003008
     requirements:
       Carp 0
+      Cpanel::JSON::XS 2.3310
       ExtUtils::CBuilder 0.27
       ExtUtils::MakeMaker 0
       File::Spec 0
@@ -5872,7 +5866,7 @@ DISTRIBUTIONS
     provides:
       Parse::BooleanLogic 0.09
     requirements:
-      ExtUtils::MakeMaker 7.1001
+      ExtUtils::MakeMaker 7.1002
       Regexp::Common 0
       Test::Deep 0
       Test::More 0
@@ -6171,6 +6165,17 @@ DISTRIBUTIONS
       Proc::FastSpawn 1.2
     requirements:
       ExtUtils::MakeMaker 0
+  Proc-ProcessTable-0.53
+    pathname: J/JW/JWB/Proc-ProcessTable-0.53.tar.gz
+    provides:
+      Proc::Killall 1.0
+      Proc::Killfam 1.0
+      Proc::ProcessTable 0.53
+      Proc::ProcessTable::Process 0.02
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Find 0
+      Storable 0
   Readonly-2.05
     pathname: S/SA/SANKO/Readonly-2.05.tar.gz
     provides:
@@ -6554,10 +6559,10 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Scalar::Util 0
       perl 5.006
-  Sub-Uplevel-0.2600
-    pathname: D/DA/DAGOLDEN/Sub-Uplevel-0.2600.tar.gz
+  Sub-Uplevel-0.2800
+    pathname: D/DA/DAGOLDEN/Sub-Uplevel-0.2800.tar.gz
     provides:
-      Sub::Uplevel 0.2600
+      Sub::Uplevel 0.2800
     requirements:
       Carp 0
       ExtUtils::MakeMaker 6.17
@@ -7237,7 +7242,7 @@ DISTRIBUTIONS
       Text::Lorem::More 0.13
       Text::Lorem::More::Source undef
     requirements:
-      ExtUtils::MakeMaker 7.1001
+      ExtUtils::MakeMaker 7.1002
       Parse::RecDescent 0
       Test::More 0
       Test::Most 0
@@ -8154,13 +8159,6 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0
-  XSLoader-0.24
-    pathname: S/SA/SAPER/XSLoader-0.24.tar.gz
-    provides:
-      XSLoader 0.24
-    requirements:
-      ExtUtils::MakeMaker 0
-      Test::More 0.47
   YAML-1.21
     pathname: I/IN/INGY/YAML-1.21.tar.gz
     provides:

--- a/install/create_default_db_user_and_databases.sh
+++ b/install/create_default_db_user_and_databases.sh
@@ -37,7 +37,7 @@ for db_selector in "${DB_CREDENTIALS_SELECTORS[@]}"; do
 EOF
 )
     createuser_exec=`run_psql "$db_credentials_host" "$createuser_sql" postgres`
-    if [[ "$createuser_exec" == *"ERROR"* ]]; then
+    if [[ "$createuser_exec" == *"ERROR"* || "$createuser_exec" == *"FATAL"* ]]; then
         if [[ "$createuser_exec" == *"already exists"* ]]; then
             echo "        User '$db_credentials_user' already exists, skipping creation."
         elif [[ -n "$createuser_exec" ]]; then
@@ -53,7 +53,7 @@ EOF
     echo "    Creating database '$db_credentials_db' on host '$db_credentials_host' with owner '$db_credentials_user'..."
     createdb_exec=`run_createdb "$db_credentials_host" "$db_credentials_db" "$db_credentials_user"`
 
-    if [[ "$createdb_exec" == *"ERROR"* ]]; then
+    if [[ "$createdb_exec" == *"ERROR"* || "$createdb_exec" == *"FATAL"* ]]; then
         if [[ "$createdb_exec" == *"already exists"* ]]; then
             echo "        Database '$db_credentials_db' already exists, skipping creation."
             echo "        If you want to purge everything and start from scratch, run purge_mediacloud_databases.sh manually."

--- a/install/install_mc_perlbrew.sh
+++ b/install/install_mc_perlbrew.sh
@@ -75,7 +75,9 @@ if [ ! -f "$PERLBREW_ROOT/bin/cpanm" ]; then
 fi
 
 echo "Creating 'mediacloud' library..."
+set +e
 perlbrew lib create "perl-${MC_PERL_VERSION}@mediacloud"
+set -e
 
 echo "Switching to 'mediacloud' library..."
 perlbrew switch "perl-${MC_PERL_VERSION}@mediacloud"

--- a/install/install_mediacloud_system_package_dependencies.sh
+++ b/install/install_mediacloud_system_package_dependencies.sh
@@ -90,7 +90,7 @@ EOF
     set +u
     if [ "$CI" == "true" ]; then
         echo "CI mode. Installing Python 3.5.3 automatically using pyenv"
-        brew install pyenv
+        brew ls --versions pyenv && brew upgrade pyenv || brew install pyenv
         pyenv install --skip-existing 3.5.3
         pyenv local 3.5.3
         pyenv rehash

--- a/install/install_mediacloud_system_package_dependencies.sh
+++ b/install/install_mediacloud_system_package_dependencies.sh
@@ -94,6 +94,15 @@ EOF
         pyenv install --skip-existing 3.5.3
         pyenv local 3.5.3
         pyenv rehash
+
+        # Install python because Travis CI has an older version already installed.
+        # Prevents this error:
+        # Error: python-2.7.12_1 already installed
+        # To install this version, first `brew unlink python`
+        #
+        # TODO: More broadly, should switch to a bash function to
+        # brew_install_or_upgrade or use brew bundle which handles this natively
+        brew ls --versions python && brew upgrade python || brew install python
     else
         # Homebrew now installs Python 3.6 by default, so we need older Python 3.5 which is best installed as a .pkg
         command -v python3.5 >/dev/null 2>&1 || {

--- a/install/install_mediacloud_system_package_dependencies.sh
+++ b/install/install_mediacloud_system_package_dependencies.sh
@@ -87,20 +87,30 @@ EOF
         exit 1
     fi
 
-    # Homebrew now installs Python 3.6 by default, so we need older Python 3.5 which is best installed as a .pkg
-    command -v python3.5 >/dev/null 2>&1 || {
-        echo "Media Cloud requires Python 3.5.+"
-        echo
-        echo "Please install the 'Mac OS X 64-bit/32-bit installer' manually from the following link:"
-        echo
-        echo "    https://www.python.org/downloads/release/python-351/"
-        echo
-        echo "Or if using pyenv, run:"
-        echo
-        echo "    pyenv install 3.5.3"
-        echo
-        exit 1
-    }
+    set +u
+    if [ "$CI" == "true" ]; then
+        echo "CI mode. Installing Python 3.5.3 automatically using pyenv"
+        brew install pyenv
+        pyenv install --skip-existing 3.5.3
+        pyenv local 3.5.3
+        pyenv rehash
+    else
+        # Homebrew now installs Python 3.6 by default, so we need older Python 3.5 which is best installed as a .pkg
+        command -v python3.5 >/dev/null 2>&1 || {
+            echo "Media Cloud requires Python 3.5.+"
+            echo
+            echo "Please install the 'Mac OS X 64-bit/32-bit installer' manually from the following link:"
+            echo
+            echo "    https://www.python.org/downloads/release/python-351/"
+            echo
+            echo "Or if using pyenv, run:"
+            echo
+            echo "    pyenv install 3.5.3"
+            echo
+            exit 1
+        }
+    fi
+    set -u
 
     echo "Installing Media Cloud dependencies with Homebrew..."
     brew install \

--- a/install/install_modules_with_carton.sh
+++ b/install/install_modules_with_carton.sh
@@ -20,6 +20,9 @@ else
     OPENSSL_PREFIX="/usr"
 fi
 
+# needed to install the https github links below
+./script/run_with_carton.sh ~/perl5/perlbrew/bin/cpanm LWP::Protocol::https
+
 # OS X no longer provides OpenSSL headers and Net::AMQP::RabbitMQ doesn't care
 # about OPENSSL_PREFIX so we need to set CCFLAGS and install the module
 # separately.
@@ -44,13 +47,18 @@ fi
 # Inline::Python needs to use virtualenv's Python 3 instead of the default Python2
 set +u; source mc-venv/bin/activate; set -u
 INLINE_PYTHON_EXECUTABLE=`command -v python3`   # `which` is a liar
+echo "Installing Inline::Python with this python executable: $INLINE_PYTHON_EXECUTABLE"
 
 # Install Inline::Python variant which die()s with tracebacks (stack traces)
 INLINE_PYTHON_EXECUTABLE=$INLINE_PYTHON_EXECUTABLE \
 ./script/run_with_carton.sh ~/perl5/perlbrew/bin/cpanm \
     --local-lib-contained local/ \
     --verbose \
-    https://github.com/pypt/inline-python-pm.git@exception_traceback_memleak
+    "https://github.com/pypt/inline-python-pm.git@exception_traceback_memleak"
+
+# Fixes: Can't locate XML/SAX.pm in @INC
+# https://rt.cpan.org/Public/Bug/Display.html?id=62289
+unset MAKEFLAGS
 
 # Install dependency modules; run the command twice because the first
 # attempt might fail

--- a/install/install_modules_with_carton.sh
+++ b/install/install_modules_with_carton.sh
@@ -20,8 +20,10 @@ else
     OPENSSL_PREFIX="/usr"
 fi
 
-# needed to install the https github links below
-./script/run_with_carton.sh ~/perl5/perlbrew/bin/cpanm LWP::Protocol::https
+if [ `uname` == 'Darwin' ]; then
+    # needed to install the https github links below
+    ./script/run_with_carton.sh ~/perl5/perlbrew/bin/cpanm LWP::Protocol::https
+fi
 
 # OS X no longer provides OpenSSL headers and Net::AMQP::RabbitMQ doesn't care
 # about OPENSSL_PREFIX so we need to set CCFLAGS and install the module

--- a/install/install_postgresql_server_packages.sh
+++ b/install/install_postgresql_server_packages.sh
@@ -38,17 +38,11 @@ if [ `uname` == 'Darwin' ]; then
         initdb /usr/local/var/postgres -E utf8
     fi
 
-    # Upgrading?    
-    if [ -f ~/Library/LaunchAgents/org.postgresql.postgres.plist ]; then
-        launchctl unload -w ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
-        ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
-    fi
-
-    # Start PostgreSQL
-    launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
+    brew services restart postgresql
     sleep 5
     createdb || echo "User's database already exists, nothing to do."    # for the current user
     createuser postgres || echo "User 'postgres' already exists, nothing to do."
+    createuser --superuser --createdb --createrole --replication root || echo "User 'root' already exists, nothing to do."
 
 else
 

--- a/install/install_python_dependencies.sh
+++ b/install/install_python_dependencies.sh
@@ -16,9 +16,9 @@ function verlt() {
 PYTHON3_MAJOR_VERSION="3.5"
 
 if [ `uname` == 'Darwin' ]; then
-    COMMAND_PREFIX = ""
+    COMMAND_PREFIX=""
 else
-    COMMAND_PREFIX = "sudo"
+    COMMAND_PREFIX="sudo"
 fi
 
 echo "Installing (upgrading) Pip..."

--- a/install/install_python_dependencies.sh
+++ b/install/install_python_dependencies.sh
@@ -15,6 +15,12 @@ function verlt() {
 # TODO: test python 3.6
 PYTHON3_MAJOR_VERSION="3.5"
 
+if [ `uname` == 'Darwin' ]; then
+    COMMAND_PREFIX = ""
+else
+    COMMAND_PREFIX = "sudo"
+fi
+
 echo "Installing (upgrading) Pip..."
 if [ `uname` == 'Darwin' ]; then
     # doesn't need get-pip as python always comes with pip installed on Mac OS X
@@ -23,10 +29,10 @@ if [ `uname` == 'Darwin' ]; then
     pip$PYTHON3_MAJOR_VERSION install --upgrade pip
 else
     # assume Ubuntu
-    wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python2.7 -
-    sudo rm setuptools-*.zip || echo "No setuptools to cleanup"
-    wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python$PYTHON3_MAJOR_VERSION -
-    sudo rm setuptools-*.zip || echo "No setuptools to cleanup"
+    wget https://bootstrap.pypa.io/get-pip.py -O - | $COMMAND_PREFIX python2.7 -
+    $COMMAND_PREFIX rm setuptools-*.zip || echo "No setuptools to cleanup"
+    wget https://bootstrap.pypa.io/get-pip.py -O - | $COMMAND_PREFIX python$PYTHON3_MAJOR_VERSION -
+    $COMMAND_PREFIX rm setuptools-*.zip || echo "No setuptools to cleanup"
 fi
 
 echo "Installing (upgrading) Supervisor..."

--- a/install/install_python_dependencies.sh
+++ b/install/install_python_dependencies.sh
@@ -23,9 +23,9 @@ if [ `uname` == 'Darwin' ]; then
     pip$PYTHON3_MAJOR_VERSION install --upgrade pip
 else
     # assume Ubuntu
-    wget https://bootstrap.pypa.io/get-pip.py -O - | $COMMAND_PREFIX python2.7 -
+    wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python2.7 -
     sudo rm setuptools-*.zip || echo "No setuptools to cleanup"
-    wget https://bootstrap.pypa.io/get-pip.py -O - | $COMMAND_PREFIX python$PYTHON3_MAJOR_VERSION -
+    wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python$PYTHON3_MAJOR_VERSION -
     sudo rm setuptools-*.zip || echo "No setuptools to cleanup"
 fi
 

--- a/install/purge_all.sh
+++ b/install/purge_all.sh
@@ -11,3 +11,4 @@ cd "$MC_ROOT_DIR"
 ./install/purge_mediacloud_databases.sh
 ./install/purge_carton_install.sh
 ./install/purge_mc_perl_brew.sh
+rm -rf mc-venv

--- a/install/set_postgresql_parameters.sh
+++ b/install/set_postgresql_parameters.sh
@@ -50,7 +50,6 @@ else
 fi
 
 for CONFIG_DIR in $CONFIG_DIRS; do
-
     POSTGRESQL_CONF_FILE_PATH="$CONFIG_DIR/postgresql.conf"
 
     if [ ! -f "$POSTGRESQL_CONF_FILE_PATH" ]; then
@@ -58,7 +57,7 @@ for CONFIG_DIR in $CONFIG_DIRS; do
         exit 1
     fi
 
-    # Create include directory to load configuration from
+    echo "Creating include directory to load configuration from..."
     CONF_D_DIR="$CONFIG_DIR/conf.d/"
     sudo mkdir -p "$CONF_D_DIR"
     sudo chown "$POSTGRESQL_USER" "$CONF_D_DIR"

--- a/mediacloud/mediawords/util/test_web.py
+++ b/mediacloud/mediawords/util/test_web.py
@@ -13,7 +13,7 @@ def test_download_file():
     assert os.path.getsize(dst_path) > 0
 
     # Nonexistent URL
-    assert_raises(McDownloadFileException, download_file, 'http://mediacloud.org/should-not-exist.txt', dst_path)
+    assert_raises(McDownloadFileException, download_file, 'https://mediacloud.org/should-not-exist.txt', dst_path)
 
 
 def test_download_file_to_temp_path():
@@ -24,4 +24,4 @@ def test_download_file_to_temp_path():
 
     # Nonexistent URL
     assert_raises(McDownloadFileToTempPathException, download_file_to_temp_path,
-                  'http://mediacloud.org/should-not-exist.txt')
+                  'https://mediacloud.org/should-not-exist.txt')


### PR DESCRIPTION
### Changes

Summary of changes:
- https://github.com/berkmancenter/mediacloud/pull/138/commits/1ed495bb41590c009cbc6b6748e80a8bb4c8a1f9 change `purge_all.sh` to delete the `mc-venv` virtual environment
- https://github.com/berkmancenter/mediacloud/pull/138/commits/9eedc9d68b82837b11d98182beadba20d5e9cb28 add echo before asking for sudo in `set_postgresql_parameters.sh`
- https://github.com/berkmancenter/mediacloud/pull/138/commits/0ac4ccf6bd457941a57dcef93f3480fcb9af8ef6 create a variable with the major python version, "3.5", that can later be more easily updated to 3.6
- https://github.com/berkmancenter/mediacloud/pull/138/commits/5898e8460cf0cacc1bdf68213c6bc265fe0e74f9 allow perlbrew lib create to fail if the library already exists
- https://github.com/berkmancenter/mediacloud/pull/138/commits/6a8d5c12a83e66b3937d5ffdb5ed9e19fa891c42 add https package to global cpanm for installation of github https modules which fail otherwise
- https://github.com/berkmancenter/mediacloud/pull/138/commits/32f20b56a2a1a096218c46ccb235e15893dcbbd0 fix error check for creratedb and createuser for postgres
- https://github.com/berkmancenter/mediacloud/pull/138/commits/2d480d426b04aa1cbe83abc7c2eab9761e44c049 add `root` postgres user because it doesn't exist on homebrew installed postgres. also use `brew services` instead of `launchctl`
- https://github.com/berkmancenter/mediacloud/pull/138/commits/ea99c71770dfd8a2289986c98710595f0441eec1 use homebrew perl as system perl on macOS. makes sudo unnecessary and also doesn't require perlbrew to compile perl from scratch anymore. force install graphviz due to some failing tests. don't hardcode vagrant path to test for vagrant
- https://github.com/berkmancenter/mediacloud/pull/138/commits/4cc413fa42e6ee45cbd3c56bad35993afb792d50 the cpanfile.snapshot changed by itself

Each commit has more details in the description.

### Testing

Tested locally on macOS 10.12.4:

```
$ ./install.sh
...
Media Cloud install succeeded!!!!
See doc/ for more information on using Media Cloud
Run ./script/start_mediacloud_server.sh to start the Media Cloud server
(Log in with email address 'jdoe@mediacloud.org' and password 'mediacloud')
```

Full Log: https://gist.github.com/AlJohri/ee219e8bf0f7bbce2845a1c2888660c1

I'm having issues with Inline::Python and virtualenv which I'll work out with @pypt when he has some time. Otherwise, I've worked around the issue and everything is running properly.

```
$ ./script/start_mediacloud_server.sh
Running plackup on Carton on PID 77264 and arguments:
HTTP::Server::PSGI: Accepting connections at http://0:5000/
^C2017-04-06 16:44:54,474 IO.Socket: ^c exiting  ...
```

cc @pypt for review