### PR TITLE
Validate urls before scraping

### DIFF
--- a/lib/MediaWords/TM/Mine.pm
+++ b/lib/MediaWords/TM/Mine.pm
@@ -21,6 +21,7 @@ use Modern::Perl "2015";
 use MediaWords::CommonLibs;
 
 import_python_module( __PACKAGE__, 'mediawords.tm.mine' );
+import_python_module( __PACKAGE__, 'mediawords.util.url' );
 
 use Carp::Always;
 use Data::Dumper;
@@ -168,6 +169,8 @@ sub get_links_from_html
         next if ( $url !~ /^http/i );
 
         next if ( $url =~ $_ignore_link_pattern );
+
+        next if ( !is_http_url( $url ) );
 
         $url =~ s/www[a-z0-9]+.nytimes/www.nytimes/i;
 


### PR DESCRIPTION
I am pattern matching a bit here, and the git commit hook (`perltidy`) failed, but then it failed when I removed my changes, so... would love a perl-literate review.

This should help #224 in the future, though I think there still needs to be a change to handle errors when they happen there.
