### PR TITLE
On "requests" exceptions, set response's body to the exception message

### DIFF
--- a/mediacloud/mediawords/util/url/__init__.py
+++ b/mediacloud/mediawords/util/url/__init__.py
@@ -81,7 +81,7 @@ def is_http_url(url: str) -> bool:
         log.debug("URL is empty")
         return False
 
-    log.info("Testing if URL '%s' is HTTP(s) URL" % url)
+    log.debug("Testing if URL '%s' is HTTP(s) URL" % url)
 
     if not re.search(__URL_REGEX, url):
         log.debug("URL '%s' does not match URL's regexp" % url)

--- a/mediacloud/mediawords/util/web/test_user_agent.py
+++ b/mediacloud/mediawords/util/web/test_user_agent.py
@@ -1410,6 +1410,36 @@ class TestUserAgentTestCase(TestCase):
 
         assert response.previous() is None
 
+    def test_get_follow_http_html_redirects_invalid_http_redirect_url(self):
+        """HTML redirects with invalid URL in HTTP redirect."""
+
+        pages = {
+            '/first': {
+                # Parsing this URL with requests / furl fails with:
+                #
+                #     UnicodeError: label empty or too long
+                #
+                'redirect': 'http://michigan-state-football-sexual-assault-charges-arrest-players-names.com',
+
+                'http_status_code': HTTPStatus.MOVED_PERMANENTLY.value,
+            },
+        }
+
+        starting_url = '%s/first' % self.__test_url
+
+        hs = HashServer(port=self.__test_port, pages=pages)
+        hs.start()
+
+        ua = UserAgent()
+
+        response = ua.get_follow_http_html_redirects(starting_url)
+
+        hs.stop()
+
+        assert response.is_success() is False
+        assert urls_are_equal(url1=response.request().url(), url2='%s/first' % self.__test_url)
+        assert "encoding with 'idna' codec failed" in response.decoded_content()
+
     def test_parallel_get(self):
         """parallel_get()."""
 


### PR DESCRIPTION
As per LWP::UserAgent's (from which we inherit our UserAgent class
design) philosophy, if the parameters are right, UserAgent should never
raise and instead always return a valid Response object. To see whether
the request has failed, one is expected to call is_success() method.

On "requests" failures (when "requests" crashes being unable to parse
something), we create a Response object for with the exception message
in its body.

Before, this was being done incorrectly. In this commit, we set the body
correctly (in a way that can later be read by response.raw.stream()) and
also test whether the exception message got returned in HTTP body.