### PR TITLE
Test normalized URL in is_http_url()

### DIFF
--- a/mediacloud/mediawords/util/test_url.py
+++ b/mediacloud/mediawords/util/test_url.py
@@ -66,6 +66,10 @@ def test_is_http_url():
     assert mc_url.is_http_url('http://127.0.0.1:12345/456789')
     assert mc_url.is_http_url('http://127.0.00000000.1:8899/tweet_url?id=47')
 
+    # Invalid IDNA
+    assert not mc_url.is_http_url('http://michigan-state-football-sexual-assault-charges-arrest-players-names')
+    assert not mc_url.is_http_url('http://michigan-state-football-sexual-assault-charges-arrest-players-names/')
+
     # Travis URL
     assert mc_url.is_http_url('http://testing-gce-286b4005-b1ae-4b1a-a0d8-faf85e39ca92:37873/gv/test.rss')
 

--- a/mediacloud/mediawords/util/url/__init__.py
+++ b/mediacloud/mediawords/util/url/__init__.py
@@ -90,8 +90,18 @@ def is_http_url(url: str) -> bool:
     try:
         uri = furl(url)
 
-        # Some URLs have invalid paths that furl's constructor doesn't check
-        _ = str(uri.path)
+        # Try stringifying URL back from the furl() object to try out all of its accessors
+        _ = str(furl)
+
+        # Some URLs become invalid when normalized (which is what "requests" will do), e.g.:
+        #
+        #     http://michigan-state-football-sexual-assault-charges-arrest-players-names -- valid
+        #     http://michigan-state-football-sexual-assault-charges-arrest-players-names/ -- invalid (decoding error)
+        #
+        # ...so try the same with normalized URL
+        normalized_url = url_normalize.url_normalize(url)
+        normalized_uri = furl(normalized_url)
+        _ = str(normalized_uri)
 
     except Exception as ex:
         log.debug("Cannot parse URL: %s" % str(ex))

--- a/mediacloud/mediawords/util/url/__init__.py
+++ b/mediacloud/mediawords/util/url/__init__.py
@@ -91,7 +91,7 @@ def is_http_url(url: str) -> bool:
         uri = furl(url)
 
         # Try stringifying URL back from the furl() object to try out all of its accessors
-        _ = str(furl)
+        _ = str(uri)
 
         # Some URLs become invalid when normalized (which is what "requests" will do), e.g.:
         #

--- a/mediacloud/mediawords/util/web/test_user_agent.py
+++ b/mediacloud/mediawords/util/web/test_user_agent.py
@@ -58,6 +58,11 @@ class TestUserAgentTestCase(TestCase):
             ua = UserAgent()
             ua.get(url='gopher://gopher.floodgap.com/0/v2/vstat')
 
+        # URL with invalid IDNA
+        with pytest.raises(McUserAgentException):
+            ua = UserAgent()
+            ua.get('http://michigan-state-football-sexual-assault-charges-arrest-players-names')
+
         pages = {'/test': 'Hello!', }
         hs = HashServer(port=self.__test_port, pages=pages)
         hs.start()
@@ -1031,6 +1036,14 @@ class TestUserAgentTestCase(TestCase):
         assert valid_auth_response.decoded_content() == 'Authenticated!'
 
         hs.stop()
+
+    def test_get_request_invalid_url(self):
+        """request() with invalid URL."""
+        with pytest.raises(McUserAgentRequestException):
+            Request(method='GET',
+
+                    # Invalid IDNA error
+                    url='http://michigan-state-football-sexual-assault-charges-arrest-players-names')
 
     def test_get_crawler_authenticated_domains(self):
         """Crawler authenticated domains (configured in mediawords.yml)."""

--- a/mediacloud/mediawords/util/web/test_user_agent.py
+++ b/mediacloud/mediawords/util/web/test_user_agent.py
@@ -1038,12 +1038,9 @@ class TestUserAgentTestCase(TestCase):
         hs.stop()
 
     def test_get_request_invalid_url(self):
-        """request() with invalid URL."""
+        """request() with invalid IDNA URL."""
         with pytest.raises(McUserAgentRequestException):
-            Request(method='GET',
-
-                    # Invalid IDNA error
-                    url='http://michigan-state-football-sexual-assault-charges-arrest-players-names')
+            Request(method='GET', url='http://michigan-state-football-sexual-assault-charges-arrest-players-names')
 
     def test_get_crawler_authenticated_domains(self):
         """Crawler authenticated domains (configured in mediawords.yml)."""


### PR DESCRIPTION
is_http_url() is a helper that we use for making sure that a string
looks like a valid URL before attempting to fetch it.

One could say that this is inexact science as the only way to find out
whether we can fetch the URL is to try to actually fetch it and catch
exceptions and whatnot. However, due to the quite big feature set of the UserAgent
class (max. size, max. redirects, HTTP / HTML redirects, backoff
retries, ...), it would be risky to add a single try-catch block around
every call to "requests" because that could hide potential programming
errors that we've made in this very young class by porting it to Python.

So, callers to UserAgent class are expected to call is_http_url() first
for their string arguments to make sure that the parameter is an URL
(otherwise one of the UserAgent's methods will do that for them and
raise an exception).

Before, is_http_url() was using furl as one of the methods of testing
the URL; however, it wasn't verifying all of its accessors, i.e. it
wasn't testing whether an URL can be constructed back from a furl
object. Because of that, is_http_url() was reporting the following URL
as valid:

http://michigan-state-football-sexual-assault-charges-arrest-players-names

...but then "requests" would normalize the URL by adding a slash to it
and subsequent calls to is_http_url() would fail for URL:

http://michigan-state-football-sexual-assault-charges-arrest-players-names/

In this commit (PR), is_http_url() stringifies parsed furl object back
to an URL and also tries to validate a normalized version of the URL.

(Hopefully) fixes #224.