### PR TITLE
Don't raise when unable to read previous response's data

### DIFF
--- a/mediacloud/mediawords/util/web/user_agent/__init__.py
+++ b/mediacloud/mediawords/util/web/user_agent/__init__.py
@@ -940,7 +940,19 @@ class UserAgent(object):
                 requests_prepared_request=previous_rq_request
             )
 
-            previous_response = Response.from_requests_response(requests_response=previous_rq_response)
+            # Sometimes reading the (chunked?) previous response's data fails with:
+            #
+            #      AttributeError: 'NoneType' object has no attribute 'readline'
+            #
+            # Previous response's data is not that important, so fail rather silently.
+            try:
+                previous_rq_response_data = previous_rq_response.text
+            except Exception as ex:
+                log.warning("Reading previous response's data failed: %s" % str(ex))
+                previous_rq_response_data = ''
+
+            previous_response = Response.from_requests_response(requests_response=previous_rq_response,
+                                                                data=previous_rq_response_data)
             previous_response.set_request(request=previous_response_request)
 
             current_response.set_previous(previous=previous_response)

--- a/mediacloud/mediawords/util/web/user_agent/response/response.py
+++ b/mediacloud/mediawords/util/web/user_agent/response/response.py
@@ -50,11 +50,8 @@ class Response(object):
         self.__set_content(data)
 
     @staticmethod
-    def from_requests_response(requests_response: requests.Response, data: str = None):
+    def from_requests_response(requests_response: requests.Response, data: str):
         """Create response from requests's Response object."""
-        if data is None:
-            data = requests_response.text
-
         return Response(
             code=requests_response.status_code,
             message=requests_response.reason,


### PR DESCRIPTION
Sometimes an attempt to read previous response's data fails with:

     AttributeError: 'NoneType' object has no attribute 'readline'

Probably related: https://github.com/requests/requests/issues/3807

Fixes #247.