### PR TITLE
Don't use __repr__ incorrectly

### DIFF
--- a/mediacloud/mediawords/util/web/user_agent/request/request.py
+++ b/mediacloud/mediawords/util/web/user_agent/request/request.py
@@ -93,8 +93,6 @@ class Request(object):
                    "data": self.content().decode('utf-8', errors='replace') if self.content() is not None else "",
                }
 
-    __str__ = __repr__
-
     def method(self) -> str:
         """Return HTTP method, e.g. GET."""
         return self.__method

--- a/mediacloud/mediawords/util/web/user_agent/response/response.py
+++ b/mediacloud/mediawords/util/web/user_agent/response/response.py
@@ -62,7 +62,7 @@ class Response(object):
             data=data,
         )
 
-    def __repr__(self):
+    def __str__(self):
 
         headers = ""
         for key, value in sorted(self.headers().items()):
@@ -79,8 +79,6 @@ class Response(object):
                    "headers": headers,
                    "data": self.decoded_content(),
                }
-
-    __str__ = __repr__
 
     def code(self) -> int:
         """Return HTTP status code, e.g. 200."""


### PR DESCRIPTION
If done my the book, `__repr__` should return something that could be eval'ed back into that object.

We only need to be able to stringify the Request / Response object (mostly for debugging purposes) so maintaining an implementation of `__repr__` is pointless.

Also, Python is probably making some brave assumptions about `__repr__` so we get weird errors such as:

     SystemError: PyEval_EvalFrameEx returned a result with an error set

(Hopefully) fixes #245 (or at least gets rid of that weird `SystemError`).