### PR TITLE
Remove __str__ / __repr__ methods in Request / Response objects

### DIFF
--- a/lib/MediaWords/Controller/Admin/Feeds.pm
+++ b/lib/MediaWords/Controller/Admin/Feeds.pm
@@ -170,7 +170,7 @@ sub invalid_syndicated_feed
     my $ua       = MediaWords::Util::Web::UserAgent->new();
     my $response = $ua->get( $feed->{ url } );
 
-    return "url fetch for '$feed->{ url }' failed: " . $response->as_string if ( !$response->is_success );
+    return "url fetch for '$feed->{ url }' failed: " . $response->decoded_content if ( !$response->is_success );
 
     eval { XML::FeedPP->new( $response->decoded_content ) };
 

--- a/lib/MediaWords/Controller/Api/V2/t/permissions.t
+++ b/lib/MediaWords/Controller/Api/V2/t/permissions.t
@@ -214,7 +214,7 @@ sub test_user_permission
 
     my $expected_code = $expect_pass ? 200 : 403;
 
-    map { ok( $_->code == $expected_code, "$message - $url: " . $_->as_string ) } @{ $responses };
+    map { ok( $_->code == $expected_code, "$message - $url: " . $_->decoded_content ) } @{ $responses };
 }
 
 # test a page with one of the permission types in the $permission_roles hash below.  verify that only

--- a/lib/MediaWords/Job/FetchTopicTweets.pm
+++ b/lib/MediaWords/Job/FetchTopicTweets.pm
@@ -57,7 +57,7 @@ sub _fetch_ch_posts ($$)
 
     if ( !$response->is_success )
     {
-        LOGDIE( "error fetching posts: " . $response->as_string );
+        LOGDIE( "error fetching posts: " . $response->decoded_content );
     }
 
     my $decoded_content = $response->decoded_content;

--- a/lib/MediaWords/Solr/WordCounts.pm
+++ b/lib/MediaWords/Solr/WordCounts.pm
@@ -445,7 +445,7 @@ sub _get_remote_words
 
     unless ( $res->is_success )
     {
-        die( "error retrieving words from solr: " . $res->as_string );
+        die( "error retrieving words from solr: " . $res->decoded_content );
     }
 
     my $words = MediaWords::Util::JSON::decode_json( $res->decoded_content );

--- a/lib/MediaWords/Test/API.pm
+++ b/lib/MediaWords/Test/API.pm
@@ -68,7 +68,7 @@ sub test_request_response($$;$)
     $url_path =~ s/\/\d+//;
     $_api_requested_urls_lookup->{ $url_path } = 1;
 
-    is( $response->is_success, !$expect_error, "HTTP response status OK for $label:\n" . $response->as_string );
+    is( $response->is_success, !$expect_error, "HTTP response status OK for $label:\n" . $response->decoded_content );
 
     my $data = eval { MediaWords::Util::JSON::decode_json( $response->decoded_content ) };
 
@@ -110,7 +110,7 @@ sub test_data_request($$$;$)
     $request->header( 'Content-Type' => 'application/json' );
     $request->content( $json );
 
-    my $label = $request->as_string;
+    my $label = "method=$method URL=$url data=$json expect_error=$expect_error";
 
     # Catalyst::Test::request()
     return test_request_response( $label, request( $request ), $expect_error );

--- a/lib/MediaWords/Util/Web/UserAgent/Request.pm
+++ b/lib/MediaWords/Util/Web/UserAgent/Request.pm
@@ -176,11 +176,4 @@ sub set_authorization_basic($$$)
     $self->{ _request }->set_authorization_basic( $username, $password );
 }
 
-sub as_string($)
-{
-    my ( $self ) = @_;
-
-    return $self->{ _request }->as_string();
-}
-
 1;

--- a/lib/MediaWords/Util/Web/UserAgent/Response.pm
+++ b/lib/MediaWords/Util/Web/UserAgent/Response.pm
@@ -119,13 +119,6 @@ sub is_success($)
     return $self->{ _response }->is_success();
 }
 
-sub as_string($)
-{
-    my ( $self ) = @_;
-
-    return $self->{ _response }->as_string();
-}
-
 sub content_type($)
 {
     my ( $self ) = @_;

--- a/lib/MediaWords/Util/Web/t/UserAgent.t
+++ b/lib/MediaWords/Util/Web/t/UserAgent.t
@@ -7,7 +7,7 @@ use MediaWords::CommonLibs;
 
 use Test::NoWarnings;
 use Test::Deep;
-use Test::More tests => 145;
+use Test::More tests => 142;
 
 use Encode;
 use File::Temp qw/ tempdir tempfile /;
@@ -346,28 +346,6 @@ sub test_get_request_headers()
     $hs->stop();
 }
 
-sub test_get_request_as_string()
-{
-    my $url = 'http://foo.com/bar';
-    my $request = MediaWords::Util::Web::UserAgent::Request->new( 'FOO', $url );
-    $request->set_header( 'X-Media-Cloud', 'mediacloud' );
-    $request->set_content( 'aaaaaaa' );
-    $request->set_authorization_basic( 'username', 'password' );
-
-    like(
-        $request->as_string(), qr|
-        ^
-        FOO\s/bar\sHTTP/1\.0\r\n
-        Host:\sfoo\.com\r\n
-        Authorization:\sBasic\s.+?\r\n
-        X-Media-Cloud:\smediacloud\r\n
-        \r\n
-        aaaaaaa
-        $
-    |ixs
-    );
-}
-
 sub test_get_response_status()
 {
     my $pages = {
@@ -450,41 +428,6 @@ sub test_get_response_content_type()
     is( $response->decoded_content(), 'pnolɔ ɐıpǝɯ' );
 
     is( $response->content_type(), 'application/xhtml+xml' );
-}
-
-sub test_get_response_as_string()
-{
-    my $pages = {
-        '/test' => {
-            header  => "Content-Type: application/xhtml+xml; charset=UTF-8\r\nX-Media-Cloud: mediacloud",
-            content => "media\ncloud\n",
-        }
-    };
-
-    my $hs = MediaWords::Test::HTTP::HashServer->new( $TEST_HTTP_SERVER_PORT, $pages );
-    $hs->start();
-
-    my $ua       = MediaWords::Util::Web::UserAgent->new();
-    my $response = $ua->get( "$TEST_HTTP_SERVER_URL/test" );
-
-    $hs->stop();
-
-    is_urls( $response->request()->url(), $TEST_HTTP_SERVER_URL . '/test' );
-
-    like(
-        $response->as_string(), qr|
-        ^
-        HTTP/1.0\s200\sOK\r\n
-        Content-Type:\sapplication/xhtml\+xml;\scharset=UTF-8\r\n
-        Date:\s.+?\r\n
-        Server:\s.+?\r\n
-        X-Media-Cloud:\smediacloud\r\n
-        \r\n
-        media\n
-        cloud\n
-        $
-    |ixs
-    );
 }
 
 sub test_get_http_request_log()
@@ -1394,11 +1337,9 @@ sub main()
     test_get_max_size();
     test_get_max_redirect();
     test_get_request_headers();
-    test_get_request_as_string();
     test_get_response_status();
     test_get_response_headers();
     test_get_response_content_type();
-    test_get_response_as_string();
     test_get_http_request_log();
     test_get_blacklisted_url();
     test_get_http_auth();

--- a/mediacloud/mediawords/util/web/test_user_agent.py
+++ b/mediacloud/mediawords/util/web/test_user_agent.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import re
 import tempfile
 import time
 from http import HTTPStatus
@@ -694,35 +693,6 @@ class TestUserAgentTestCase(TestCase):
             'none-header-is-defined': False,
         }
 
-    def test_get_request_as_string(self):
-        """Request's as_string() method."""
-        # FIXME move to a separate unit test file
-
-        url = 'http://foo.com/bar?a=b'
-        username = 'username'
-        password = 'password'
-
-        request = Request(method='FOO', url=url)
-        request.set_header(name='X-Media-Cloud', value='mediacloud')
-        request.set_content(b'aaaaaaa')
-        request.set_authorization_basic(username=username, password=password)
-
-        request_string = request.as_string()
-        assert re.search(
-            pattern=r"""
-                ^
-                FOO\s/bar\?a=b\sHTTP/1\.0\r\n
-                Host:\sfoo\.com\r\n
-                Authorization:\sBasic\s.+?\r\n
-                X-Media-Cloud:\smediacloud\r\n
-                \r\n
-                aaaaaaa
-                $
-            """,
-            string=request_string,
-            flags=re.IGNORECASE | re.UNICODE | re.VERBOSE
-        )
-
     def test_get_response_status(self):
         """HTTP status code and message."""
 
@@ -846,45 +816,6 @@ class TestUserAgentTestCase(TestCase):
         assert response.decoded_content() == 'pnolɔ ɐıpǝɯ'
 
         assert response.content_type() == 'application/xhtml+xml'
-
-    def test_get_response_as_string(self):
-        """Response's as_string() method."""
-
-        pages = {
-            '/test': {
-                'header': "Content-Type: application/xhtml+xml; charset=UTF-8\r\nX-Media-Cloud: mediacloud",
-                'content': "media\ncloud\n",
-            },
-        }
-
-        hs = HashServer(port=self.__test_port, pages=pages)
-        hs.start()
-
-        ua = UserAgent()
-        test_url = '%s/test' % self.__test_url
-        response = ua.get(test_url)
-
-        hs.stop()
-
-        assert urls_are_equal(url1=response.request().url(), url2=test_url)
-
-        response_string = response.as_string()
-        assert re.match(
-            pattern=r"""
-                ^
-                HTTP/1.0\s200\sOK\r\n
-                Content-Type:\sapplication/xhtml\+xml;\scharset=UTF-8\r\n
-                Date:\s.+?\r\n
-                Server:\s.+?\r\n
-                X-Media-Cloud:\smediacloud\r\n
-                \r\n
-                media\n
-                cloud\n
-                $
-            """,
-            string=response_string,
-            flags=re.UNICODE | re.VERBOSE | re.IGNORECASE
-        )
 
     def test_get_http_request_log(self):
         """HTTP request log."""

--- a/mediacloud/mediawords/util/web/user_agent/request/request.py
+++ b/mediacloud/mediawords/util/web/user_agent/request/request.py
@@ -56,43 +56,6 @@ class Request(object):
 
         return request
 
-    def __repr__(self) -> str:
-        """Return something similar to what will be sent to the server for this request."""
-
-        uri = furl(self.url())
-        path_query = str(uri.path)
-        if len(str(uri.query)):
-            path_query += "?" + str(uri.query)
-
-        http_auth = ""
-        if self.auth_username() and self.auth_password():
-            base64_auth = base64.b64encode(
-                ('%s:%s' % (self.auth_username(), self.auth_password(),)).encode('ascii')
-            ).decode('ascii')
-            http_auth = "Authorization: Basic %s\r\n" % base64_auth
-
-        headers = ""
-        for key, value in sorted(self.headers().items()):
-            headers = headers + "%s: %s\r\n" % (key, value,)
-
-        return (
-                   "%(method)s %(path_query)s HTTP/1.0\r\n"
-                   "Host: %(host)s\r\n"
-                   "%(http_auth)s"
-                   "%(headers)s"
-                   "\r\n"
-                   "%(data)s"
-               ) % {
-                   "method": self.method(),
-                   "path_query": path_query,
-                   "host": uri.host,
-                   "http_auth": http_auth,
-                   "headers": headers,
-
-                   # FIXME probably doesn't support non-UTF-8 POSTs
-                   "data": self.content().decode('utf-8', errors='replace') if self.content() is not None else "",
-               }
-
     def method(self) -> str:
         """Return HTTP method, e.g. GET."""
         return self.__method
@@ -232,7 +195,3 @@ class Request(object):
     def auth_password(self):
         """Return HTTP authentication password."""
         return self.__auth_password
-
-    def as_string(self) -> str:
-        """Return string representation of the request."""
-        return str(self)

--- a/mediacloud/mediawords/util/web/user_agent/response/response.py
+++ b/mediacloud/mediawords/util/web/user_agent/response/response.py
@@ -59,24 +59,6 @@ class Response(object):
             data=data,
         )
 
-    def __str__(self):
-
-        headers = ""
-        for key, value in sorted(self.headers().items()):
-            headers = headers + "%s: %s\r\n" % (key, value,)
-
-        return (
-                   "HTTP/1.0 %(code)d %(message)s\r\n"
-                   "%(headers)s"
-                   "\r\n"
-                   "%(data)s"
-               ) % {
-                   "code": self.code(),
-                   "message": self.message(),
-                   "headers": headers,
-                   "data": self.decoded_content(),
-               }
-
     def code(self) -> int:
         """Return HTTP status code, e.g. 200."""
         return self.__code
@@ -233,7 +215,3 @@ class Response(object):
         while original_response.previous():
             original_response = original_response.previous()
         return original_response.request()
-
-    def as_string(self) -> str:
-        """Return string representation of the response."""
-        return str(self)

--- a/script/mediawords_download_and_handle_feed.pl
+++ b/script/mediawords_download_and_handle_feed.pl
@@ -56,7 +56,7 @@ sub main
     if ( !$response->is_success )
     {
         $db->query( "update downloads set state = 'error' where downloads_id = ?", $download->{ downloads_id } );
-        die( "error fetching download: " . $response->as_string );
+        die( "error fetching download: " . $response->decoded_content );
     }
 
     $handler->handle_download( $db, $download, $response->decoded_content );

--- a/script/mediawords_fetch_url.pl
+++ b/script/mediawords_fetch_url.pl
@@ -25,7 +25,7 @@ sub main
 
     my $response = $ua->get( $url );
 
-    print $response->as_string;
+    print $response->decoded_content;
 }
 
 main();


### PR DESCRIPTION
I only halfway know what I'm doing here, but it appears that:

1. `UserAgent`'s `Request` and `Response` objects have `__str__()` implemented which returns human-readable string representation of the object
2. Both classes have Perl-ish `as_string()` method which is an alias for `__str__()`. `as_string()` was mostly used for debugging reasons.
3. Some Python code (I wasn't able to identify which, but probably not ours) was stringifying various `Response` objects for unknown reasons and printing them to STDOUT.
4. Python's `encode()` (or, in this case, `decode()?` I'm not sure) seems to be able to handle Unicode surrogate characters (e.g. `\ud800`) but raises `UnicodeEncodeError` when trying to print them to STDOUT.
5. So, as a result I've removed `__str__()` and `as_string()` methods so that no surrogate characters are attempted at being printed to STDOUT (or at least now it would be easier to find out which of our own code - if any - attempts to print said characters).

(Hopefully) fixes #245.

No unit tests because no new code, also not quite sure what to test (as I honestly don't know which code calls `__str__()`).

Not requesting a review for this comparably small and experimental fix.
