### PR TITLE
Rewrite color palette generator code to Python

### DIFF
--- a/ansible/roles/perl-dependencies/vars/main.yml
+++ b/ansible/roles/perl-dependencies/vars/main.yml
@@ -42,7 +42,6 @@ perl_dependencies:
     - "Catalyst::View::TT"
     - "CGI"
     - "CHI"
-    - "Color::Mix"
     - "Crypt::SaltedHash"
     - "Data::Dumper"
     - "Data::Serializer"

--- a/lib/MediaWords/Util/Colors.pm
+++ b/lib/MediaWords/Util/Colors.pm
@@ -4,59 +4,8 @@ use strict;
 use warnings;
 
 use Modern::Perl "2015";
-use MediaWords::CommonLibs;
+use MediaWords::CommonLibs;    # set PYTHONPATH too
 
-use Color::Mix;
-
-# util functions that help dealing with colors, including color pallette generation
-
-my $_mc_colors = [
-    '1f77b4', 'aec7e8', 'ff7f0e', 'ffbb78', '2ca02c', '98df8a', 'd62728', 'ff9896', '9467bd', 'c5b0d5',
-    '8c564b', 'c49c94', 'e377c2', 'f7b6d2', '7f7f7f', 'c7c7c7', 'bcbd22', 'dbdb8d', '17becf', '9edae5',
-    '84c4ce', 'ffa779', 'cc5ace', '6f11c9', '6f3e5d'
-];
-
-# return the same color for the same set / id combination every time this function
-# is called
-sub get_consistent_color
-{
-    my ( $db, $set, $id ) = @_;
-
-    # always return grey for null or not typed values
-    return '999999' if ( grep { lc( $id ) eq $_ } ( 'null', 'not typed' ) );
-
-    my ( $color ) = $db->query( 'select color from color_sets where color_set = ? and id = ?', $set, $id )->flat;
-
-    return $color if ( $color );
-
-    my $set_colors = $db->query( 'select color from color_sets where color_set = ?', $set )->flat;
-
-    my $existing_colors = {};
-    map { $existing_colors->{ $_ } = 1 } @{ $set_colors };
-
-    # use the hard coded pallete of 25 colors if possible
-    my $new_color;
-    for my $c ( @{ $_mc_colors } )
-    {
-        if ( !$existing_colors->{ $c } )
-        {
-            $new_color = $c;
-            last;
-        }
-    }
-
-    # otherwise, just generate a random color
-    if ( !$new_color )
-    {
-        my $color_mix = Color::Mix->new;
-        my $colors = [ $color_mix->analogous( '0000ff', 255, 255 ) ];
-
-        $new_color = $colors->[ int( rand() * 255 ) ];
-    }
-
-    $db->create( 'color_sets', { color_set => $set, id => $id, color => $new_color } );
-
-    return $new_color;
-}
+import_python_module( __PACKAGE__, 'mediawords.util.colors' );
 
 1;

--- a/lib/MediaWords/Util/Colors.pm
+++ b/lib/MediaWords/Util/Colors.pm
@@ -6,6 +6,8 @@ use warnings;
 use Modern::Perl "2015";
 use MediaWords::CommonLibs;
 
+use Color::Mix;
+
 # util functions that help dealing with colors, including color pallette generation
 
 my $_mc_colors = [
@@ -13,50 +15,6 @@ my $_mc_colors = [
     '8c564b', 'c49c94', 'e377c2', 'f7b6d2', '7f7f7f', 'c7c7c7', 'bcbd22', 'dbdb8d', '17becf', '9edae5',
     '84c4ce', 'ffa779', 'cc5ace', '6f11c9', '6f3e5d'
 ];
-
-# accept hex format [ FFFFFF ] and return rgb() format [ rgb(255,255,255) ]
-sub _get_rgbp_format
-{
-    my ( $hex ) = @_;
-
-    return 'rgb(' .
-      hex( substr( $hex, 0, 2 ) ) . ',' .
-      hex( substr( $hex, 2, 2 ) ) . ',' .
-      hex( substr( $hex, 4, 2 ) ) . ')';
-}
-
-# return a pallete of $num_colors distinct colors.  if format is 'rgb()', return in rgb() format, otherwise return in hex format.
-sub _get_colors
-{
-    my ( $num_colors, $format ) = @_;
-
-    $num_colors ||= @{ $_mc_colors };
-
-    my $colors;
-    if ( $num_colors <= @{ $_mc_colors } )
-    {
-        $colors = [ ( @{ $_mc_colors } )[ 0 .. ( $num_colors - 1 ) ] ];
-    }
-    else
-    {
-        use Color::Mix;
-        my $color_mix = Color::Mix->new;
-        $colors = [ $color_mix->analogous( '0000ff', $num_colors, $num_colors ) ];
-    }
-
-    if ( !$format || $format eq 'hex' )
-    {
-        return $colors;
-    }
-    elsif ( $format eq 'rgb()' )
-    {
-        return [ map { _get_rgbp_format( $_ ) } @{ $colors } ];
-    }
-    else
-    {
-        die( "Unknown format '$format'" );
-    }
-}
 
 # return the same color for the same set / id combination every time this function
 # is called
@@ -78,7 +36,7 @@ sub get_consistent_color
 
     # use the hard coded pallete of 25 colors if possible
     my $new_color;
-    for my $c ( @{ _get_colors() } )
+    for my $c ( @{ $_mc_colors } )
     {
         if ( !$existing_colors->{ $c } )
         {
@@ -90,7 +48,6 @@ sub get_consistent_color
     # otherwise, just generate a random color
     if ( !$new_color )
     {
-        use Color::Mix;
         my $color_mix = Color::Mix->new;
         my $colors = [ $color_mix->analogous( '0000ff', 255, 255 ) ];
 

--- a/lib/MediaWords/Util/t/Colors.t
+++ b/lib/MediaWords/Util/t/Colors.t
@@ -3,12 +3,11 @@ use warnings;
 
 use utf8;
 use Test::NoWarnings;
-use Test::More tests => 16;
+use Test::More tests => 166;
 
 use MediaWords::Test::DB;
 
 use_ok( 'MediaWords::Util::Colors' );
-
 
 sub test_consistent_colors
 {
@@ -58,12 +57,46 @@ sub test_consistent_colors
     is( $color_c_baz_2, $color_c_baz, 'color_a_baz is consistent' );
 }
 
+sub test_consistent_colors_create($)
+{
+    my ( $db ) = @_;
+
+    my $set = 'test_set';
+
+    my $unique_color_mapping = {};
+
+    # Test if helper is able to create new colors when it runs out of hardcoded set
+    for ( my $x = 0 ; $x < 50 ; ++$x )
+    {
+        my $id = "color-$x";
+        my $color = MediaWords::Util::Colors::get_consistent_color( $db, $set, $id );
+        is( length( $color ), length( 'ffffff' ) );
+        $unique_color_mapping->{ $id } = $color;
+    }
+
+    # Make sure that if we run it again, we'll get the same colors
+    for ( my $x = 0 ; $x < 50 ; ++$x )
+    {
+        my $id = "color-$x";
+        my $color = MediaWords::Util::Colors::get_consistent_color( $db, $set, $id );
+        is( length( $color ),               length( 'ffffff' ) );
+        is( $unique_color_mapping->{ $id }, $color );
+    }
+}
+
 sub main
 {
     MediaWords::Test::DB::test_on_test_database(
         sub {
             my ( $db ) = @_;
             test_consistent_colors( $db );
+        }
+    );
+
+    MediaWords::Test::DB::test_on_test_database(
+        sub {
+            my ( $db ) = @_;
+            test_consistent_colors_create( $db );
         }
     );
 }

--- a/mediacloud/mediawords/util/colors.py
+++ b/mediacloud/mediawords/util/colors.py
@@ -26,20 +26,22 @@ def rgb_to_hex(r: int, g: int, b: int) -> str:
     return '%02x%02x%02x' % (int(r), int(g), int(b),)
 
 
-def analogous_color(color: str, my_slices: int = 3, slices: int = 32) -> List[str]:
-    """Analogous color schemes are ones in which the colors lie next to each other on the color wheel.
+def analogous_color(color: str, return_slices: int = 4, split_slices: int = 12) -> List[str]:
+    """Generate analogous color scheme starting with the provided color.
 
-    By default this method splits up the colorwheel into 12 pieces and returns the next 3 pieces of the wheel. So using
-    this if you entered 0000ff (blue) then by default you would get back '80000ff' (purple), 'ff00ff' (pink) and
-    'ff0080' (hotpink) colors.
+    Analogous color scheme is the one in which the colors lie next to each other on the color wheel.
 
-    If you split the wheel up into 36 as in the example above you essentially reduce the range of the colors by 3. So
-    now if you entered 0000ff (blue) but added a parameter 3 (For number of colors you want returned) and 36 (To split
-    the wheel up into 36 pieces) then you would get back '2b00ff' (Blue), '5500ff' (Bluey Purple) and '8000ff' (Purple).
+    By default this method splits up the color wheel into 12 pieces and returns the original parameter color plus the
+    next 3 pieces of the wheel (4 colors in total). For example, by padding '0000ff' (blue) you would get back '0000ff'
+    (blue -- the original color) '80000ff' (purple), 'ff00ff' (pink) and 'ff0080' (hot pink) colors.
 
-    This gives and easy way to either limit or expand the range of the analogous color palette.
+    Ported from https://metacpan.org/pod/Color::Mix#analogous().
 
-    Ported from https://metacpan.org/pod/Color::Mix#analogous()."""
+    :param color: Starting color
+    :param return_slices: Number of color slices to return
+    :param split_slices: Number of slices to split the color wheel into
+    :return: Generated colors starting with the parameter color
+    """
     color = decode_object_from_bytes_if_needed(color)
 
     def shift_hue(hue: int, angle_: float) -> int:
@@ -57,10 +59,10 @@ def analogous_color(color: str, my_slices: int = 3, slices: int = 32) -> List[st
         b = int(b)
         return rgb_to_hex(r, g, b)
 
-    angle = 360 / slices
+    angle = 360 / split_slices
 
     colors = [color]
-    for x in range(1, my_slices + 1):
+    for x in range(1, return_slices):
         new_color = rotate_color(color_=color, angle_=angle * x)
         colors.append(new_color)
 
@@ -104,7 +106,7 @@ def get_consistent_color(db: DatabaseHandler, item_set: str, item_id: str) -> st
 
     # Otherwise, just generate a random color
     if new_color is None:
-        colors = analogous_color(color='0000ff', my_slices=255, slices=255)
+        colors = analogous_color(color='0000ff', return_slices=256, split_slices=255)
         new_color = random.choice(colors)
 
     db.create(table='color_sets', insert_hash={

--- a/mediacloud/mediawords/util/colors.py
+++ b/mediacloud/mediawords/util/colors.py
@@ -1,0 +1,116 @@
+import random
+from colorsys import hsv_to_rgb, rgb_to_hsv
+from typing import List
+
+from mediawords.db import DatabaseHandler
+from mediawords.util.perl import decode_object_from_bytes_if_needed
+
+__MC_COLORS = [
+    '1f77b4', 'aec7e8', 'ff7f0e', 'ffbb78', '2ca02c',
+    '98df8a', 'd62728', 'ff9896', '9467bd', 'c5b0d5',
+    '8c564b', 'c49c94', 'e377c2', 'f7b6d2', '7f7f7f',
+    'c7c7c7', 'bcbd22', 'dbdb8d', '17becf', '9edae5',
+    '84c4ce', 'ffa779', 'cc5ace', '6f11c9', '6f3e5d',
+]
+
+
+def hex_to_rgb(hex_color: str) -> tuple:
+    """Get R, G, B channels from hex color, e.g. "FF0000"."""
+    if hex_color.startswith('#'):
+        hex_color = hex_color[1:]
+    return tuple(int(hex_color[i:i + 2], 16) for i in (0, 2, 4))
+
+
+def rgb_to_hex(r: int, g: int, b: int) -> str:
+    """Get hex color (e.g. "FF0000") from R, G, B channels."""
+    return '%02x%02x%02x' % (int(r), int(g), int(b),)
+
+
+def analogous_color(color: str, my_slices: int = 3, slices: int = 32) -> List[str]:
+    """Analogous color schemes are ones in which the colors lie next to each other on the color wheel.
+
+    By default this method splits up the colorwheel into 12 pieces and returns the next 3 pieces of the wheel. So using
+    this if you entered 0000ff (blue) then by default you would get back '80000ff' (purple), 'ff00ff' (pink) and
+    'ff0080' (hotpink) colors.
+
+    If you split the wheel up into 36 as in the example above you essentially reduce the range of the colors by 3. So
+    now if you entered 0000ff (blue) but added a parameter 3 (For number of colors you want returned) and 36 (To split
+    the wheel up into 36 pieces) then you would get back '2b00ff' (Blue), '5500ff' (Bluey Purple) and '8000ff' (Purple).
+
+    This gives and easy way to either limit or expand the range of the analogous color palette.
+
+    Ported from https://metacpan.org/pod/Color::Mix#analogous()."""
+    color = decode_object_from_bytes_if_needed(color)
+
+    def shift_hue(hue: int, angle_: float) -> int:
+        return int((hue + angle_) % 360)
+
+    def rotate_color(color_: str, angle_: float) -> str:
+        r, g, b = hex_to_rgb(color_)
+        h, s, v = rgb_to_hsv(r, g, b)
+        h *= 360
+        h = shift_hue(hue=h, angle_=angle_)
+        h /= 360
+        r, g, b = hsv_to_rgb(h, s, v)
+        r = int(r)
+        g = int(g)
+        b = int(b)
+        return rgb_to_hex(r, g, b)
+
+    angle = 360 / slices
+
+    colors = [color]
+    for x in range(1, my_slices + 1):
+        new_color = rotate_color(color_=color, angle_=angle * x)
+        colors.append(new_color)
+
+    return colors
+
+
+def get_consistent_color(db: DatabaseHandler, item_set: str, item_id: str) -> str:
+    """Return the same hex color (e.g. "ff0000" for the same set / ID combination every time this function is called."""
+    item_set = decode_object_from_bytes_if_needed(item_set)
+    item_id = decode_object_from_bytes_if_needed(item_id)
+
+    # Always return grey for null or not typed values
+    if item_id.lower() in {'null', 'not typed'}:
+        return '999999'
+
+    color = db.query("""SELECT color FROM color_sets WHERE color_set = %(item_set)s AND id = %(item_id)s""", {
+        'item_set': item_set,
+        'item_id': item_id,
+    }).flat()
+    if color is not None and len(color):
+        if isinstance(color, list):
+            color = color[0]
+        return color
+
+    set_colors = db.query("""SELECT color FROM color_sets WHERE color_set = %(item_set)s""", {
+        'item_set': item_set,
+    }).flat()
+
+    existing_colors = set()
+
+    if set_colors is not None:
+        for color in set_colors:
+            existing_colors.add(color)
+
+    # Use the hard coded palette of 25 colors if possible
+    new_color = None
+    for color in __MC_COLORS:
+        if color in existing_colors:
+            new_color = color
+            break
+
+    # Otherwise, just generate a random color
+    if new_color is None:
+        colors = analogous_color(color='0000ff', my_slices=255, slices=255)
+        new_color = random.choice(colors)
+
+    db.create(table='color_sets', insert_hash={
+        'color_set': item_set,
+        'id': item_id,
+        'color': new_color,
+    })
+
+    return new_color

--- a/mediacloud/mediawords/util/colors.py
+++ b/mediacloud/mediawords/util/colors.py
@@ -98,7 +98,7 @@ def get_consistent_color(db: DatabaseHandler, item_set: str, item_id: str) -> st
     # Use the hard coded palette of 25 colors if possible
     new_color = None
     for color in __MC_COLORS:
-        if color in existing_colors:
+        if color not in existing_colors:
             new_color = color
             break
 

--- a/mediacloud/mediawords/util/test_colors.py
+++ b/mediacloud/mediawords/util/test_colors.py
@@ -78,6 +78,9 @@ class TestGetConsistentColorTestCase(TestDatabaseWithSchemaTestCase):
             assert len(color) == len('ffffff')
             unique_color_mapping[item_id] = color
 
+        # Make sure the first color is from the Media Cloud color palette
+        assert unique_color_mapping['color-0'] == '1f77b4'
+
         # Make sure that if we run it again, we'll get the same colors
         for x in range(50):
             item_id = 'color-%d' % x

--- a/mediacloud/mediawords/util/test_colors.py
+++ b/mediacloud/mediawords/util/test_colors.py
@@ -17,7 +17,12 @@ def test_rgb_to_hex():
 
 def test_analogous_color():
     starting_color = '0000ff'
-    colors = analogous_color(color=starting_color, my_slices=255, slices=255)
+
+    colors = analogous_color(color=starting_color, return_slices=1, split_slices=255)
+    assert len(colors) == 1
+    assert colors[0].lower() == starting_color
+
+    colors = analogous_color(color=starting_color, return_slices=256, split_slices=255)
     assert len(colors) == 256
     assert colors[0].lower() == starting_color
     assert colors[1].lower() == '0400ff'

--- a/mediacloud/mediawords/util/test_colors.py
+++ b/mediacloud/mediawords/util/test_colors.py
@@ -33,6 +33,7 @@ def test_analogous_color():
 class TestGetConsistentColorTestCase(TestDatabaseWithSchemaTestCase):
 
     def test_get_consistent_color(self):
+        # Colors that "color_sets" were prefilled with in mediawords.sql
         partisan_colors = {
             'partisan_2012_conservative': 'c10032',
             'partisan_2012_liberal': '00519b',

--- a/mediacloud/mediawords/util/test_colors.py
+++ b/mediacloud/mediawords/util/test_colors.py
@@ -1,0 +1,86 @@
+from mediawords.test.test_database import TestDatabaseWithSchemaTestCase
+from mediawords.util.colors import *
+
+
+def test_hex_to_rgb():
+    assert hex_to_rgb('ff0000') == (255, 0, 0,)
+    assert hex_to_rgb('FFFFFF') == (255, 255, 255,)
+    assert hex_to_rgb('#ff0000') == (255, 0, 0,)
+    assert hex_to_rgb('#FFFFFF') == (255, 255, 255,)
+
+
+def test_rgb_to_hex():
+    assert rgb_to_hex(255, 0, 0).lower() == 'ff0000'
+    assert rgb_to_hex(0, 0, 0).lower() == '000000'
+    assert rgb_to_hex(255, 255, 255).lower() == 'ffffff'
+
+
+def test_analogous_color():
+    starting_color = '0000ff'
+    colors = analogous_color(color=starting_color, my_slices=255, slices=255)
+    assert len(colors) == 256
+    assert colors[0].lower() == starting_color
+    assert colors[1].lower() == '0400ff'
+    assert colors[-2].lower() == '0008ff'
+    assert colors[-1].lower() == starting_color
+
+
+class TestGetConsistentColorTestCase(TestDatabaseWithSchemaTestCase):
+
+    def test_get_consistent_color(self):
+        partisan_colors = {
+            'partisan_2012_conservative': 'c10032',
+            'partisan_2012_liberal': '00519b',
+            'partisan_2012_libertarian': '009543',
+        }
+
+        for color_id, color in partisan_colors.items():
+            got_color = get_consistent_color(db=self.db(), item_set='partisan_code', item_id=color_id)
+            assert got_color == color
+
+        color_c_baz = get_consistent_color(db=self.db(), item_set='c', item_id='baz')
+        color_b_baz = get_consistent_color(db=self.db(), item_set='b', item_id='baz')
+        color_b_bar = get_consistent_color(db=self.db(), item_set='b', item_id='bar')
+        color_a_baz = get_consistent_color(db=self.db(), item_set='a', item_id='baz')
+        color_a_bar = get_consistent_color(db=self.db(), item_set='a', item_id='bar')
+        color_a_foo = get_consistent_color(db=self.db(), item_set='a', item_id='foo')
+
+        num_db_colors = self.db().query("SELECT COUNT(*) FROM color_sets").flat()
+        assert num_db_colors[0] == 9
+
+        assert color_a_foo != color_a_bar
+        assert color_a_foo != color_a_baz
+        assert color_a_bar != color_a_baz
+        assert color_b_bar != color_b_baz
+
+        color_a_foo_2 = get_consistent_color(db=self.db(), item_set='a', item_id='foo')
+        color_a_bar_2 = get_consistent_color(db=self.db(), item_set='a', item_id='bar')
+        color_a_baz_2 = get_consistent_color(db=self.db(), item_set='a', item_id='baz')
+        color_b_bar_2 = get_consistent_color(db=self.db(), item_set='b', item_id='bar')
+        color_b_baz_2 = get_consistent_color(db=self.db(), item_set='b', item_id='baz')
+        color_c_baz_2 = get_consistent_color(db=self.db(), item_set='c', item_id='baz')
+
+        assert color_a_foo_2 == color_a_foo
+        assert color_a_bar_2 == color_a_bar
+        assert color_a_baz_2 == color_a_baz
+        assert color_b_bar_2 == color_b_bar
+        assert color_b_baz_2 == color_b_baz
+        assert color_c_baz_2 == color_c_baz
+
+    def test_consistent_colors_create(self):
+        item_set = 'test_set'
+        unique_color_mapping = dict()
+
+        # Test if helper is able to create new colors when it runs out of hardcoded set
+        for x in range(50):
+            item_id = 'color-%d' % x
+            color = get_consistent_color(db=self.db(), item_set=item_set, item_id=item_id)
+            assert len(color) == len('ffffff')
+            unique_color_mapping[item_id] = color
+
+        # Make sure that if we run it again, we'll get the same colors
+        for x in range(50):
+            item_id = 'color-%d' % x
+            color = get_consistent_color(db=self.db(), item_set=item_set, item_id=item_id)
+            assert len(color) == len('ffffff')
+            assert unique_color_mapping[item_id] == color


### PR DESCRIPTION
Some web UI code needs to generate matching color palettes for coloring various partisanships and whatnot.

I rewrote color palette generator to Python. Should work identically to the Perl code.

I've tried to find an analogous color palette generator to Python but failed so I rewrote some of the [`Color::Mix`](https://metacpan.org/pod/Color::Mix) helpers to Python too.