### PR TITLE
Fix vagrant S3 key-value store tests

### DIFF
--- a/mediacloud/mediawords/key_value_store/test_amazon_s3.py
+++ b/mediacloud/mediawords/key_value_store/test_amazon_s3.py
@@ -1,10 +1,12 @@
 import pytest
 
 from mediawords.key_value_store.amazon_s3 import AmazonS3Store
-from mediawords.key_value_store.test_amazon_s3_credentials import TestAmazonS3CredentialsTestCase, test_s3_credentials
+from mediawords.key_value_store.test_amazon_s3_credentials import (
+    TestAmazonS3CredentialsTestCase,
+    get_test_s3_credentials,
+)
 
-
-test_credentials = test_s3_credentials()
+test_credentials = get_test_s3_credentials()
 
 pytest_amazon_s3_credentials_set = pytest.mark.skipif(
     test_credentials is None,

--- a/mediacloud/mediawords/key_value_store/test_amazon_s3_credentials.py
+++ b/mediacloud/mediawords/key_value_store/test_amazon_s3_credentials.py
@@ -10,7 +10,7 @@ from mediawords.util.config import get_config as py_get_config
 from mediawords.util.text import random_string
 
 
-def test_s3_credentials() -> Union[dict, None]:
+def get_test_s3_credentials() -> Union[dict, None]:
     """Return test Amazon S3 credentials as a dictionary or None if credentials are not configured."""
 
     config = py_get_config()
@@ -36,7 +36,7 @@ def test_s3_credentials() -> Union[dict, None]:
     return credentials
 
 
-test_credentials = test_s3_credentials()
+test_credentials = get_test_s3_credentials()
 
 pytest_amazon_s3_credentials_set = pytest.mark.skipif(
     test_credentials is None,

--- a/mediacloud/mediawords/key_value_store/test_amazon_s3_credentials.py
+++ b/mediacloud/mediawords/key_value_store/test_amazon_s3_credentials.py
@@ -31,7 +31,8 @@ def get_test_s3_credentials() -> Union[dict, None]:
         credentials = copy.deepcopy(config['amazon_s3']['test'])
 
     # We want to be able to run S3 tests in parallel
-    credentials['directory_name'] = credentials['directory_name'] + '-' + random_string(64)
+    if credentials is not None:
+        credentials['directory_name'] = credentials['directory_name'] + '-' + random_string(64)
 
     return credentials
 

--- a/mediacloud/mediawords/key_value_store/test_cached_amazon_s3.py
+++ b/mediacloud/mediawords/key_value_store/test_cached_amazon_s3.py
@@ -1,9 +1,12 @@
 import pytest
 
 from mediawords.key_value_store.cached_amazon_s3 import CachedAmazonS3Store
-from mediawords.key_value_store.test_amazon_s3_credentials import TestAmazonS3CredentialsTestCase, test_s3_credentials
+from mediawords.key_value_store.test_amazon_s3_credentials import (
+    TestAmazonS3CredentialsTestCase,
+    get_test_s3_credentials,
+)
 
-test_credentials = test_s3_credentials()
+test_credentials = get_test_s3_credentials()
 
 pytest_amazon_s3_credentials_set = pytest.mark.skipif(
     test_credentials is None,

--- a/mediacloud/mediawords/key_value_store/test_multiple_stores.py
+++ b/mediacloud/mediawords/key_value_store/test_multiple_stores.py
@@ -3,10 +3,13 @@ import pytest
 from mediawords.key_value_store.amazon_s3 import AmazonS3Store
 from mediawords.key_value_store.multiple_stores import MultipleStoresStore
 from mediawords.key_value_store.postgresql import PostgreSQLStore
-from mediawords.key_value_store.test_amazon_s3_credentials import TestAmazonS3CredentialsTestCase, test_s3_credentials
+from mediawords.key_value_store.test_amazon_s3_credentials import (
+    TestAmazonS3CredentialsTestCase,
+    get_test_s3_credentials,
+)
 from mediawords.key_value_store.test_mock_download import TestMockDownloadTestCase
 
-test_credentials = test_s3_credentials()
+test_credentials = get_test_s3_credentials()
 
 pytest_amazon_s3_credentials_set = pytest.mark.skipif(
     test_credentials is None,

--- a/script/vagrant/Vagrantfile
+++ b/script/vagrant/Vagrantfile
@@ -13,7 +13,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 # AMI (see https://cloud-images.ubuntu.com/locator/ec2/)
 # ("us-east-1 xenial 16.04 LTS amd64 hvm:ebs-ssd")
-AWS_AMI           = ENV['AWS_AMI']            || "ami-1d4e7a66"
+AWS_AMI           = ENV['AWS_AMI']            || "ami-41e0b93b"
 AWS_REGION        = ENV['AWS_REGION']         || "us-east-1"
 AWS_INSTANCE_NAME = ENV['AWS_INSTANCE_NAME']  || "Media Cloud Vagrant test box"
 


### PR DESCRIPTION
We have a [Vagrant configuration](https://github.com/berkmancenter/mediacloud/blob/fix_vagrant_s3_tests/script/vagrant/Vagrantfile) set up to make it easier to install Media Cloud. To make sure that this Vagrant configuration is working, we automatically run it once a day as a Cron job.

Recently, it has been failing with:

```
---
==> default: :634: in _load_backward_compatible
==> default:     ???
==> default: ../.virtualenvs/mediacloud/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:212: in load_module
==> default:     py.builtin.exec_(co, mod.__dict__)
==> default: mediacloud/mediawords/key_value_store/test_amazon_s3_credentials.py:39: in <module>
==> default:     test_credentials = test_s3_credentials()
==> default: mediacloud/mediawords/key_value_store/test_amazon_s3_credentials.py:34: in test_s3_credentials
==> default:     credentials['directory_name'] = credentials['directory_name'] + '-' + random_string(64)
==> default: E   TypeError: 'NoneType' object is not subscriptable
==> default:  ERROR collecting mediacloud/mediawords/key_value_store/test_multiple_stores.py 
==> default: mediacloud/mediawords/key_value_store/test_multiple_stores.py:6: in <module>
==> default:     from mediawords.key_value_store.test_amazon_s3_credentials import TestAmazonS3CredentialsTestCase, test_s3_credentials
==> default: <frozen importlib._bootstrap>:969: in _find_and_load
==> default:     ???
==> default: <frozen importlib._bootstrap>:958: in _find_and_load_unlocked
==> default:     ???
==> default: <frozen importlib._bootstrap>:664: in _load_unlocked
==> default:     ???
==> default: <frozen importlib._bootstrap>:634: in _load_backward_compatible
==> default:     ???
==> default: ../.virtualenvs/mediacloud/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:212: in load_module
==> default:     py.builtin.exec_(co, mod.__dict__)
==> default: mediacloud/mediawords/key_value_store/test_amazon_s3_credentials.py:39: in <module>
==> default:     test_credentials = test_s3_credentials()
==> default: mediacloud/mediawords/key_value_store/test_amazon_s3_credentials.py:34: in test_s3_credentials
==> default:     credentials['directory_name'] = credentials['directory_name'] + '-' + random_string(64)
==> default: E   TypeError: 'NoneType' object is not subscriptable
==> default: !!!!!!!!!!!!!!!!!!! Interrupted: 4 errors during collection !!!!!!!!!!!!!!!!!!!!
==> default: =========================== 4 error in 6.68 seconds ============================
```

The failure was due to a misnamed method which pytest thought was a test method, also due to S3 credentials not being set on Vagrant instances. Colin fixed this in his https://github.com/berkmancenter/mediacloud/pull/238 (part of d44df878671cc30d685133ff7ac7cf8d541bac14) but [didn't adjust the fix by removing unrelated changes](https://github.com/berkmancenter/mediacloud/pull/238#issuecomment-350326401) so I'll do it again here.