### PR TITLE
Fix Colors.t Perl unit test

### DIFF
--- a/lib/MediaWords/Util/t/Colors.t
+++ b/lib/MediaWords/Util/t/Colors.t
@@ -9,21 +9,9 @@ use MediaWords::Test::DB;
 
 use_ok( 'MediaWords::Util::Colors' );
 
-sub test_consistent_colors
+sub test_get_consistent_color
 {
     my ( $db ) = @_;
-
-    my $partisan_colors = {
-        partisan_2012_conservative => 'c10032',
-        partisan_2012_liberal      => '00519b',
-        partisan_2012_libertarian  => '009543'
-    };
-
-    while ( my ( $id, $color ) = each( %{ $partisan_colors } ) )
-    {
-        my $got_color = MediaWords::Util::Colors::get_consistent_color( $db, 'partisan_code', $id );
-        is( $got_color, $color, "color for partisan id '$id'" );
-    }
 
     my $color_c_baz = MediaWords::Util::Colors::get_consistent_color( $db, 'c', 'baz' );
     my $color_b_baz = MediaWords::Util::Colors::get_consistent_color( $db, 'b', 'baz' );
@@ -57,7 +45,24 @@ sub test_consistent_colors
     is( $color_c_baz_2, $color_c_baz, 'color_a_baz is consistent' );
 }
 
-sub test_consistent_colors_create($)
+sub test_get_consistent_color_partisan
+{
+    my ( $db ) = @_;
+
+    my $partisan_colors = {
+        partisan_2012_conservative => 'c10032',
+        partisan_2012_liberal      => '00519b',
+        partisan_2012_libertarian  => '009543'
+    };
+
+    while ( my ( $id, $color ) = each( %{ $partisan_colors } ) )
+    {
+        my $got_color = MediaWords::Util::Colors::get_consistent_color( $db, 'partisan_code', $id );
+        is( $got_color, $color, "color for partisan id '$id'" );
+    }
+}
+
+sub test_get_consistent_color_create($)
 {
     my ( $db ) = @_;
 
@@ -89,14 +94,21 @@ sub main
     MediaWords::Test::DB::test_on_test_database(
         sub {
             my ( $db ) = @_;
-            test_consistent_colors( $db );
+            test_get_consistent_color( $db );
         }
     );
 
     MediaWords::Test::DB::test_on_test_database(
         sub {
             my ( $db ) = @_;
-            test_consistent_colors_create( $db );
+            test_get_consistent_color_partisan( $db );
+        }
+    );
+
+    MediaWords::Test::DB::test_on_test_database(
+        sub {
+            my ( $db ) = @_;
+            test_get_consistent_color_create( $db );
         }
     );
 }

--- a/mediacloud/mediawords/util/colors.py
+++ b/mediacloud/mediawords/util/colors.py
@@ -90,6 +90,9 @@ def get_consistent_color(db: DatabaseHandler, item_set: str, item_id: str) -> st
     set_colors = db.query("""SELECT color FROM color_sets WHERE color_set = %(item_set)s""", {
         'item_set': item_set,
     }).flat()
+    if set_colors is not None:
+        if not isinstance(set_colors, list):
+            set_colors = [set_colors]
 
     existing_colors = set()
 

--- a/mediacloud/mediawords/util/test_colors.py
+++ b/mediacloud/mediawords/util/test_colors.py
@@ -33,17 +33,6 @@ def test_analogous_color():
 class TestGetConsistentColorTestCase(TestDatabaseWithSchemaTestCase):
 
     def test_get_consistent_color(self):
-        # Colors that "color_sets" were prefilled with in mediawords.sql
-        partisan_colors = {
-            'partisan_2012_conservative': 'c10032',
-            'partisan_2012_liberal': '00519b',
-            'partisan_2012_libertarian': '009543',
-        }
-
-        for color_id, color in partisan_colors.items():
-            got_color = get_consistent_color(db=self.db(), item_set='partisan_code', item_id=color_id)
-            assert got_color == color
-
         color_c_baz = get_consistent_color(db=self.db(), item_set='c', item_id='baz')
         color_b_baz = get_consistent_color(db=self.db(), item_set='b', item_id='baz')
         color_b_bar = get_consistent_color(db=self.db(), item_set='b', item_id='bar')
@@ -73,7 +62,19 @@ class TestGetConsistentColorTestCase(TestDatabaseWithSchemaTestCase):
         assert color_b_baz_2 == color_b_baz
         assert color_c_baz_2 == color_c_baz
 
-    def test_consistent_colors_create(self):
+    def test_get_consistent_color_partisan(self):
+        """Colors that "color_sets" were pre-filled with in mediawords.sql."""
+        partisan_colors = {
+            'partisan_2012_conservative': 'c10032',
+            'partisan_2012_liberal': '00519b',
+            'partisan_2012_libertarian': '009543',
+        }
+
+        for color_id, color in partisan_colors.items():
+            got_color = get_consistent_color(db=self.db(), item_set='partisan_code', item_id=color_id)
+            assert got_color == color
+
+    def test_get_consistent_color_create(self):
         item_set = 'test_set'
         unique_color_mapping = dict()
 


### PR DESCRIPTION
Fixes mess-up with Perl returning an array to code that expects an arrayref (some more detail in 2b8da63, please ask for clarification if you require more details about what's happening).

Also, splits partisan colors test into a separate subroutine.