### PR TITLE
Disable live Superglue feed testing as it's down for quite some time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,10 @@ env:
         # Superglue test feed URL:
         #
         # * MC_SUPERGLUE_TEST_URL
-        - secure: "BzZcSjsuihkDowYPRz0F2HRiZ9LbEJkPXJpL8sRTBp1exbKAyfQ2+pXm3k2d34utp/gNiLlL+GFDmm7dr9wZ82DSqouBC8UJa3gaL/AeBrdXngaJbBeUqIWiDhsZFkf5F3V0J3r+7CxEAQVhU8hAPE7LB4VFjSYgXGZfoAMcdCw="
+        #
+        # (Disabled because Superglue live feeds are currently down)
+        #
+        #- secure: "BzZcSjsuihkDowYPRz0F2HRiZ9LbEJkPXJpL8sRTBp1exbKAyfQ2+pXm3k2d34utp/gNiLlL+GFDmm7dr9wZ82DSqouBC8UJa3gaL/AeBrdXngaJbBeUqIWiDhsZFkf5F3V0J3r+7CxEAQVhU8hAPE7LB4VFjSYgXGZfoAMcdCw="
 
         # Do not ask for confirmation when running ./script/mediawords_create_db.pl
         - MEDIAWORDS_CREATE_DB_DO_NOT_CONFIRM=1


### PR DESCRIPTION
Live Superglue feeds have been down for quite some time breaking our test build, so I'm temporarily disabling the live feed test.

I'll create a `-systems` issue on reenabling those feeds.