### PR TITLE
Bump date guesser version

### DIFF
--- a/ansible/roles/python-dependencies/files/requirements.txt
+++ b/ansible/roles/python-dependencies/files/requirements.txt
@@ -17,7 +17,7 @@ coverage==4.4.1
 CyHunspell==1.2.1
 
 # Guessing publication dates of stories
-date_guesser==2.1.0
+date_guesser==2.1.1
 
 # URL manipulation
 furl==1.0.1

--- a/ansible/roles/python-dependencies/files/requirements.txt
+++ b/ansible/roles/python-dependencies/files/requirements.txt
@@ -17,7 +17,7 @@ coverage==4.4.1
 CyHunspell==1.2.1
 
 # Guessing publication dates of stories
-date_guesser==2.0.0
+date_guesser==2.1.0
 
 # URL manipulation
 furl==1.0.1


### PR DESCRIPTION
Just published a new version of `date_guesser` that will fix the problem in #272.

This was the tag:
`<time datetime="2015-26-26T04:03:40Z" pubdate>Thursday, Mar. 26 2015, 12:26 AM EDT</time>`

Which caused problems when the date parser matched the `datetime` text, but then tried to set the month to 26.  

`date_guesser` now guards against such errors, and has a backup parser for this particular case.

Fixes #272 