### PR TITLE
Ignore UnicodeEncodeError in log_dead_link()

### DIFF
--- a/lib/MediaWords/TM/Mine.pm
+++ b/lib/MediaWords/TM/Mine.pm
@@ -860,11 +860,47 @@ sub log_dead_link
         url        => $link->{ url }
     };
 
-    INFO "INSERTing into 'topic_dead_links': " . Dumper( $dead_link );
+    eval { $db->create( 'topic_dead_links', $dead_link ); };
+    if ( $@ )
+    {
+        my $error_message = $@;
 
-    $db->create( 'topic_dead_links', $dead_link );
-
-    INFO "INSERTed into 'topic_dead_links': " . Dumper( $dead_link );
+        # MC_REWRITE_TO_PYTHON:
+        #
+        # Some calls to create() fail with:
+        #
+        #      UnicodeEncodeError: 'utf-8' codec can't encode character '\udf33' in position 26352: surrogates not allowed
+        #
+        # for insert hash:
+        #
+        #     {
+        #         'stories_id' => 629277868,
+        #         'url' => 'http://www.thatssomichelle.com/2011/11/pumpkin-mac-and-cheese.html',
+        #         'topics_id' => 2030,
+        #     }
+        #
+        # I wish I knew what's causing this, but I don't. Unable to reproduce
+        # either -- calling create() with a failing hash in an isolated script
+        # works fine, so maybe it's related to the caller somehow? No idea.
+        #
+        # So here we silently ignore one-off UnicodeEncodeError exceptions
+        # because "topic_dead_links" table is used for statistics, and it's not
+        # a big deal if some links fail at create() here.
+        #
+        # One should try removing this exception after this code gets rewritten
+        # to Python because it might be related to Inline::Python's memory
+        # management or exception handling.
+        if ( $error_message =~ /UnicodeEncodeError.+?surrogates not allowed/ )
+        {
+            WARN "Non-critical UnicodeEncodeError while trying to INSERT " .
+              Dumper( $dead_link ) . " into 'topic_dead_links': $error_message";
+        }
+        else
+        {
+            # die() on all other exceptions
+            LOGCONFESS "Failed INSERTing into 'topic_dead_links': $error_message";
+        }
+    }
 }
 
 # send story to the extraction queue in the hope that it will already be extracted by the time we get to the extraction


### PR DESCRIPTION
I gave up and added an `eval{}` around the failing `$db->create( 'topic_dead_links', ... )` call.

More details in the commit (510c84d).

Fixes #245 (I hope!).