### PR TITLE
Bump coverage, keep tool configuration in setup.cfg

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[report]
-omit = */test_*.py, */snowball/python/*.py

--- a/ansible/roles/python-dependencies/files/requirements.txt
+++ b/ansible/roles/python-dependencies/files/requirements.txt
@@ -11,7 +11,7 @@ Celery==4.1.0
 cld2-cffi==0.1.4
 
 # Unit test coverage
-coverage==4.4.1
+coverage==4.4.2
 
 # Hindi stemming
 CyHunspell==1.2.1

--- a/mediacloud/setup.cfg
+++ b/mediacloud/setup.cfg
@@ -1,3 +1,6 @@
 [flake8]
 max-line-length = 120
 exclude = mediawords/languages
+
+[coverage:run]
+omit = */test_*.py, */snowball/python/*.py

--- a/script/run_test_suite.sh
+++ b/script/run_test_suite.sh
@@ -48,7 +48,7 @@ if [ ! -z ${MC_TEST_SUITE_REPORT_COVERAGE+x} ]; then
     export HARNESS_PERL_SWITCHES='-MDevel::Cover=+ignore,t/,+ignore,\.t$'
 
     # Enable Python's pytest coverage
-    PYTEST_ARGS="--cov=mediacloud/mediawords/ --cov-config==mediacloud/setup.cfg"
+    PYTEST_ARGS="--cov=mediacloud/mediawords/ --cov-config=mediacloud/setup.cfg"
 
 else
 

--- a/script/run_test_suite.sh
+++ b/script/run_test_suite.sh
@@ -48,7 +48,7 @@ if [ ! -z ${MC_TEST_SUITE_REPORT_COVERAGE+x} ]; then
     export HARNESS_PERL_SWITCHES='-MDevel::Cover=+ignore,t/,+ignore,\.t$'
 
     # Enable Python's pytest coverage
-    PYTEST_ARGS="--cov=mediacloud/mediawords/ --cov-config=.coveragerc"
+    PYTEST_ARGS="--cov=mediacloud/mediawords/ --cov-config==mediacloud/setup.cfg"
 
 else
 


### PR DESCRIPTION
Followup to #278 .  It looks like ignoring --cov-config was a known issue with `coverage` (https://github.com/pytest-dev/pytest-cov/issues/180), and is now fixed.