### PR TITLE
Reenable Superglue live feed testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,7 @@ env:
         # Superglue test feed URL:
         #
         # * MC_SUPERGLUE_TEST_URL
-        #
-        # (Disabled because Superglue live feeds are currently down)
-        #
-        #- secure: "BzZcSjsuihkDowYPRz0F2HRiZ9LbEJkPXJpL8sRTBp1exbKAyfQ2+pXm3k2d34utp/gNiLlL+GFDmm7dr9wZ82DSqouBC8UJa3gaL/AeBrdXngaJbBeUqIWiDhsZFkf5F3V0J3r+7CxEAQVhU8hAPE7LB4VFjSYgXGZfoAMcdCw="
+        - secure: "BzZcSjsuihkDowYPRz0F2HRiZ9LbEJkPXJpL8sRTBp1exbKAyfQ2+pXm3k2d34utp/gNiLlL+GFDmm7dr9wZ82DSqouBC8UJa3gaL/AeBrdXngaJbBeUqIWiDhsZFkf5F3V0J3r+7CxEAQVhU8hAPE7LB4VFjSYgXGZfoAMcdCw="
 
         # Do not ask for confirmation when running ./script/mediawords_create_db.pl
         - MEDIAWORDS_CREATE_DB_DO_NOT_CONFIRM=1


### PR DESCRIPTION
Kalli from Superglue have fixed the live feed that they're providing us with, so we can continue using it for our remote testing.