### PR TITLE
Partition "stories_tags_map" table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,7 @@ env:
         # Superglue test feed URL:
         #
         # * MC_SUPERGLUE_TEST_URL
-        #
-        # (Disabled because Superglue live feeds are currently down)
-        #
-        #- secure: "BzZcSjsuihkDowYPRz0F2HRiZ9LbEJkPXJpL8sRTBp1exbKAyfQ2+pXm3k2d34utp/gNiLlL+GFDmm7dr9wZ82DSqouBC8UJa3gaL/AeBrdXngaJbBeUqIWiDhsZFkf5F3V0J3r+7CxEAQVhU8hAPE7LB4VFjSYgXGZfoAMcdCw="
+        - secure: "BzZcSjsuihkDowYPRz0F2HRiZ9LbEJkPXJpL8sRTBp1exbKAyfQ2+pXm3k2d34utp/gNiLlL+GFDmm7dr9wZ82DSqouBC8UJa3gaL/AeBrdXngaJbBeUqIWiDhsZFkf5F3V0J3r+7CxEAQVhU8hAPE7LB4VFjSYgXGZfoAMcdCw="
 
         # Do not ask for confirmation when running ./script/mediawords_create_db.pl
         - MEDIAWORDS_CREATE_DB_DO_NOT_CONFIRM=1

--- a/schema/mediawords.sql
+++ b/schema/mediawords.sql
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
 DECLARE
     -- Database schema version number (same as a SVN revision number)
     -- Increase it by 1 if you make major database schema changes.
-    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4641;
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4642;
 
 BEGIN
 
@@ -891,30 +891,155 @@ create table feeds_stories_map
 create unique index feeds_stories_map_feed on feeds_stories_map (feeds_id, stories_id);
 create index feeds_stories_map_story on feeds_stories_map (stories_id);
 
-create table stories_tags_map
-(
-    stories_tags_map_id     serial  primary key,
-    stories_id              int     not null references stories on delete cascade,
-    tags_id                 int     not null references tags on delete cascade,
-    db_row_last_updated                timestamp with time zone not null default now()
-);
 
-DROP TRIGGER IF EXISTS stories_tags_map_last_updated_trigger on stories_tags_map CASCADE;
+--
+-- Story -> tag map
+--
+
+CREATE OR REPLACE FUNCTION stories_tags_map_partition_chunk_size()
+RETURNS BIGINT AS $$
+BEGIN
+    RETURN 100 * 1000 * 1000;   -- 100m stories in each partition
+END; $$
+LANGUAGE plpgsql IMMUTABLE;
+
+-- "Master" table (no indexes, no foreign keys as they'll be ineffective)
+CREATE TABLE stories_tags_map (
+    stories_tags_map_id     BIGSERIAL   NOT NULL,
+    stories_id              INT         NOT NULL,
+    tags_id                 INT         NOT NULL,
+    db_row_last_updated     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
 
 CREATE TRIGGER stories_tags_map_last_updated_trigger
     BEFORE INSERT OR UPDATE ON stories_tags_map
-    FOR EACH ROW EXECUTE PROCEDURE last_updated_trigger() ;
-
-DROP TRIGGER IF EXISTS stories_tags_map_update_stories_last_updated_trigger on stories_tags_map;
+    FOR EACH ROW EXECUTE PROCEDURE last_updated_trigger();
 
 CREATE TRIGGER stories_tags_map_update_stories_last_updated_trigger
     AFTER INSERT OR UPDATE OR DELETE ON stories_tags_map
     FOR EACH ROW EXECUTE PROCEDURE update_stories_updated_time_by_stories_id_trigger();
 
-CREATE index stories_tags_map_db_row_last_updated on stories_tags_map ( db_row_last_updated );
-create unique index stories_tags_map_story on stories_tags_map (stories_id, tags_id);
-create index stories_tags_map_tag on stories_tags_map (tags_id);
-CREATE INDEX stories_tags_map_story_id ON stories_tags_map USING btree (stories_id);
+
+CREATE OR REPLACE FUNCTION stories_tags_map_get_partition_name(stories_id BIGINT, table_name TEXT)
+RETURNS TEXT AS $$
+DECLARE
+    to_char_format CONSTANT TEXT := '00';     -- Up to 100 partitions, suffixed as "_00", "_01" ..., "_99"
+                                              -- (having more of them is not feasible)
+    stories_id_chunk_number INT;
+
+    target_table_name TEXT;       -- partition table name (e.g. "stories_tags_map_01")
+BEGIN
+    SELECT stories_id / stories_tags_map_partition_chunk_size() INTO stories_id_chunk_number;
+
+    SELECT table_name || '_' || trim(leading ' ' FROM to_char(stories_id_chunk_number, to_char_format))
+        INTO target_table_name;
+
+    RETURN target_table_name;
+END;
+$$
+LANGUAGE plpgsql;
+
+
+-- Create missing stories_tags_map partitions
+CREATE OR REPLACE FUNCTION stories_tags_map_create_partitions()
+RETURNS VOID AS
+$$
+DECLARE
+    chunk_size INT;
+    max_stories_id BIGINT;
+    partition_stories_id BIGINT;
+
+    target_table_name TEXT;       -- partition table name (e.g. "stories_tags_map_01")
+    target_table_owner TEXT;      -- partition table owner (e.g. "mediaclouduser")
+
+    stories_id_start INT;         -- stories_id chunk lower limit, inclusive (e.g. 30,000,000)
+    stories_id_end INT;           -- stories_id chunk upper limit, exclusive (e.g. 31,000,000)
+BEGIN
+
+    SELECT stories_tags_map_partition_chunk_size() INTO chunk_size;
+
+    -- Create +1 partition for future insertions
+    SELECT COALESCE(MAX(stories_id), 0) + chunk_size FROM stories INTO max_stories_id;
+
+    FOR partition_stories_id IN 1..max_stories_id BY chunk_size LOOP
+        SELECT stories_tags_map_get_partition_name( partition_stories_id, 'stories_tags_map' ) INTO target_table_name;
+        IF table_exists(target_table_name) THEN
+            RAISE NOTICE 'Partition "%" for story ID % already exists.', target_table_name, partition_stories_id;
+        ELSE
+            RAISE NOTICE 'Creating partition "%" for story ID %', target_table_name, partition_stories_id;
+
+            SELECT (partition_stories_id / chunk_size) * chunk_size INTO stories_id_start;
+            SELECT ((partition_stories_id / chunk_size) + 1) * chunk_size INTO stories_id_end;
+
+            EXECUTE '
+                CREATE TABLE ' || target_table_name || ' (
+
+                    PRIMARY KEY (stories_tags_map_id),
+
+                    -- Partition by stories_id
+                    CONSTRAINT ' || REPLACE(target_table_name, '.', '_') || '_stories_id CHECK (
+                        stories_id >= ''' || stories_id_start || '''
+                    AND stories_id <  ''' || stories_id_end   || '''),
+
+                    -- Foreign key to stories.stories_id
+                    CONSTRAINT ' || REPLACE(target_table_name, '.', '_') || '_stories_id_fkey
+                        FOREIGN KEY (stories_id) REFERENCES stories (stories_id) MATCH FULL,
+
+                    -- Foreign key to tags.tags_id
+                    CONSTRAINT ' || REPLACE(target_table_name, '.', '_') || '_tags_id_fkey
+                        FOREIGN KEY (tags_id) REFERENCES tags (tags_id) MATCH FULL,
+
+                    -- Unique duplets
+                    CONSTRAINT ' || REPLACE(target_table_name, '.', '_') || '_stories_id_tags_id_unique
+                        UNIQUE (stories_id, tags_id)
+
+                ) INHERITS (stories_tags_map);
+            ';
+
+            -- Update owner
+            SELECT u.usename AS owner
+            FROM information_schema.tables AS t
+                JOIN pg_catalog.pg_class AS c ON t.table_name = c.relname
+                JOIN pg_catalog.pg_user AS u ON c.relowner = u.usesysid
+            WHERE t.table_name = 'stories_tags_map'
+              AND t.table_schema = 'public'
+            INTO target_table_owner;
+
+            EXECUTE 'ALTER TABLE ' || target_table_name || ' OWNER TO ' || target_table_owner || ';';
+
+        END IF;
+    END LOOP;
+
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create initial partitions for empty database
+SELECT stories_tags_map_create_partitions();
+
+
+-- Upsert row into correct partition
+CREATE OR REPLACE FUNCTION stories_tags_map_partition_by_stories_id_insert_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_table_name TEXT;       -- partition table name (e.g. "stories_tags_map_01")
+BEGIN
+    SELECT stories_tags_map_get_partition_name( NEW.stories_id, 'stories_tags_map' ) INTO target_table_name;
+    EXECUTE '
+        INSERT INTO ' || target_table_name || '
+            SELECT $1.*
+        ON CONFLICT (stories_id, tags_id) DO NOTHING 
+        ' USING NEW;
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER stories_tags_map_partition_by_stories_id_insert_trigger
+    BEFORE INSERT ON stories_tags_map
+    FOR EACH ROW EXECUTE PROCEDURE stories_tags_map_partition_by_stories_id_insert_trigger();
+
+
 
 CREATE TABLE download_texts (
     download_texts_id integer NOT NULL,
@@ -2672,6 +2797,10 @@ BEGIN
     -- "bitly_clicks_total" table
     RAISE NOTICE 'Creating partitions in "bitly_clicks_total" table...';
     PERFORM bitly_clicks_total_create_partitions();
+
+    -- "stories_tags_map" table
+    RAISE NOTICE 'Creating partitions in "stories_tags_map" table...';
+    PERFORM stories_tags_map_create_partitions();
 END;
 $$
 LANGUAGE plpgsql;

--- a/schema/mediawords.sql
+++ b/schema/mediawords.sql
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
 DECLARE
     -- Database schema version number (same as a SVN revision number)
     -- Increase it by 1 if you make major database schema changes.
-    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4640;
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4641;
 
 BEGIN
 
@@ -69,15 +69,31 @@ $$ LANGUAGE SQL;
 
 
 -- Returns true if table exists (and user has access to it)
+-- Table name might be with ("public.stories") or without ("stories") schema.
 CREATE OR REPLACE FUNCTION table_exists(target_table_name VARCHAR)
 RETURNS BOOLEAN AS $$
+DECLARE
+    schema_position INT;
+    schema VARCHAR;
 BEGIN
+
+    SELECT POSITION('.' IN target_table_name) INTO schema_position;
+
+    -- "." at string index 0 would return position 1
+    IF schema_position = 0 THEN
+        schema := CURRENT_SCHEMA();
+    ELSE
+        schema := SUBSTRING(target_table_name FROM 1 FOR schema_position - 1);
+        target_table_name := SUBSTRING(target_table_name FROM schema_position + 1);
+    END IF;
+
     RETURN EXISTS (
         SELECT 1
         FROM information_schema.tables
-        WHERE table_schema = CURRENT_SCHEMA()
+        WHERE table_schema = schema
           AND table_name = target_table_name
     );
+
 END;
 $$
 LANGUAGE plpgsql;

--- a/schema/migrations/mediawords-4640-4641.sql
+++ b/schema/migrations/mediawords-4640-4641.sql
@@ -1,0 +1,71 @@
+--
+-- This is a Media Cloud PostgreSQL schema difference file (a "diff") between schema
+-- versions 4640 and 4641.
+--
+-- If you are running Media Cloud with a database that was set up with a schema version
+-- 4640, and you would like to upgrade both the Media Cloud and the
+-- database to be at version 4641, import this SQL file:
+--
+--     psql mediacloud < mediawords-4640-4641.sql
+--
+-- You might need to import some additional schema diff files to reach the desired version.
+--
+
+--
+-- 1 of 2. Import the output of 'apgdiff':
+--
+
+SET search_path = public, pg_catalog;
+
+
+CREATE OR REPLACE FUNCTION table_exists(target_table_name VARCHAR) RETURNS BOOLEAN AS $$
+DECLARE
+    schema_position INT;
+    schema VARCHAR;
+BEGIN
+
+    SELECT POSITION('.' IN target_table_name) INTO schema_position;
+
+    -- "." at string index 0 would return position 1
+    IF schema_position = 0 THEN
+        schema := CURRENT_SCHEMA();
+    ELSE
+        schema := SUBSTRING(target_table_name FROM 1 FOR schema_position - 1);
+        target_table_name := SUBSTRING(target_table_name FROM schema_position + 1);
+    END IF;
+
+    RETURN EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = schema
+          AND table_name = target_table_name
+    );
+
+END;
+$$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
+DECLARE
+    -- Database schema version number (same as a SVN revision number)
+    -- Increase it by 1 if you make major database schema changes.
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4641;
+
+BEGIN
+
+    -- Update / set database schema version
+    DELETE FROM database_variables WHERE name = 'database-schema-version';
+    INSERT INTO database_variables (name, value) VALUES ('database-schema-version', MEDIACLOUD_DATABASE_SCHEMA_VERSION::int);
+
+    return true;
+
+END;
+$$
+LANGUAGE 'plpgsql';
+
+--
+-- 2 of 2. Reset the database version.
+--
+SELECT set_database_schema_version();
+

--- a/schema/migrations/mediawords-4641-4642.sql
+++ b/schema/migrations/mediawords-4641-4642.sql
@@ -1,0 +1,196 @@
+--
+-- This is a Media Cloud PostgreSQL schema difference file (a "diff") between schema
+-- versions 4641 and 4642.
+--
+-- If you are running Media Cloud with a database that was set up with a schema version
+-- 4641, and you would like to upgrade both the Media Cloud and the
+-- database to be at version 4642, import this SQL file:
+--
+--     psql mediacloud < mediawords-4641-4642.sql
+--
+-- You might need to import some additional schema diff files to reach the desired version.
+--
+
+--
+-- 1 of 2. Import the output of 'apgdiff':
+--
+
+SET search_path = public, pg_catalog;
+
+
+ALTER TABLE stories_tags_map RENAME TO stories_tags_map_old;
+
+
+CREATE OR REPLACE FUNCTION stories_tags_map_partition_chunk_size()
+RETURNS BIGINT AS $$
+BEGIN
+    RETURN 100 * 1000 * 1000;   -- 100m stories in each partition
+END; $$
+LANGUAGE plpgsql IMMUTABLE;
+
+-- "Master" table (no indexes, no foreign keys as they'll be ineffective)
+CREATE TABLE stories_tags_map (
+    stories_tags_map_id     BIGSERIAL   NOT NULL,
+    stories_id              INT         NOT NULL,
+    tags_id                 INT         NOT NULL,
+    db_row_last_updated     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER stories_tags_map_last_updated_trigger
+    BEFORE INSERT OR UPDATE ON stories_tags_map
+    FOR EACH ROW EXECUTE PROCEDURE last_updated_trigger();
+
+CREATE TRIGGER stories_tags_map_update_stories_last_updated_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON stories_tags_map
+    FOR EACH ROW EXECUTE PROCEDURE update_stories_updated_time_by_stories_id_trigger();
+
+
+CREATE OR REPLACE FUNCTION stories_tags_map_get_partition_name(stories_id BIGINT, table_name TEXT)
+RETURNS TEXT AS $$
+DECLARE
+    to_char_format CONSTANT TEXT := '00';     -- Up to 100 partitions, suffixed as "_00", "_01" ..., "_99"
+                                              -- (having more of them is not feasible)
+    stories_id_chunk_number INT;
+
+    target_table_name TEXT;       -- partition table name (e.g. "stories_tags_map_01")
+BEGIN
+    SELECT stories_id / stories_tags_map_partition_chunk_size() INTO stories_id_chunk_number;
+
+    SELECT table_name || '_' || trim(leading ' ' FROM to_char(stories_id_chunk_number, to_char_format))
+        INTO target_table_name;
+
+    RETURN target_table_name;
+END;
+$$
+LANGUAGE plpgsql;
+
+
+-- Create missing stories_tags_map partitions
+CREATE OR REPLACE FUNCTION stories_tags_map_create_partitions()
+RETURNS VOID AS
+$$
+DECLARE
+    chunk_size INT;
+    max_stories_id BIGINT;
+    partition_stories_id BIGINT;
+
+    target_table_name TEXT;       -- partition table name (e.g. "stories_tags_map_01")
+    target_table_owner TEXT;      -- partition table owner (e.g. "mediaclouduser")
+
+    stories_id_start INT;         -- stories_id chunk lower limit, inclusive (e.g. 30,000,000)
+    stories_id_end INT;           -- stories_id chunk upper limit, exclusive (e.g. 31,000,000)
+BEGIN
+
+    SELECT stories_tags_map_partition_chunk_size() INTO chunk_size;
+
+    -- Create +1 partition for future insertions
+    SELECT COALESCE(MAX(stories_id), 0) + chunk_size FROM stories INTO max_stories_id;
+
+    FOR partition_stories_id IN 1..max_stories_id BY chunk_size LOOP
+        SELECT stories_tags_map_get_partition_name( partition_stories_id, 'stories_tags_map' ) INTO target_table_name;
+        IF table_exists(target_table_name) THEN
+            RAISE NOTICE 'Partition "%" for story ID % already exists.', target_table_name, partition_stories_id;
+        ELSE
+            RAISE NOTICE 'Creating partition "%" for story ID %', target_table_name, partition_stories_id;
+
+            SELECT (partition_stories_id / chunk_size) * chunk_size INTO stories_id_start;
+            SELECT ((partition_stories_id / chunk_size) + 1) * chunk_size INTO stories_id_end;
+
+            EXECUTE '
+                CREATE TABLE ' || target_table_name || ' (
+
+                    PRIMARY KEY (stories_tags_map_id),
+
+                    -- Partition by stories_id
+                    CONSTRAINT ' || REPLACE(target_table_name, '.', '_') || '_stories_id CHECK (
+                        stories_id >= ''' || stories_id_start || '''
+                    AND stories_id <  ''' || stories_id_end   || '''),
+
+                    -- Foreign key to stories.stories_id
+                    CONSTRAINT ' || REPLACE(target_table_name, '.', '_') || '_stories_id_fkey
+                        FOREIGN KEY (stories_id) REFERENCES stories (stories_id) MATCH FULL,
+
+                    -- Foreign key to tags.tags_id
+                    CONSTRAINT ' || REPLACE(target_table_name, '.', '_') || '_tags_id_fkey
+                        FOREIGN KEY (tags_id) REFERENCES tags (tags_id) MATCH FULL,
+
+                    -- Unique duplets
+                    CONSTRAINT ' || REPLACE(target_table_name, '.', '_') || '_stories_id_tags_id_unique
+                        UNIQUE (stories_id, tags_id)
+
+                ) INHERITS (stories_tags_map);
+            ';
+
+            -- Update owner
+            SELECT u.usename AS owner
+            FROM information_schema.tables AS t
+                JOIN pg_catalog.pg_class AS c ON t.table_name = c.relname
+                JOIN pg_catalog.pg_user AS u ON c.relowner = u.usesysid
+            WHERE t.table_name = 'stories_tags_map'
+              AND t.table_schema = 'public'
+            INTO target_table_owner;
+
+            EXECUTE 'ALTER TABLE ' || target_table_name || ' OWNER TO ' || target_table_owner || ';';
+
+        END IF;
+    END LOOP;
+
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Create initial partitions for empty database
+SELECT stories_tags_map_create_partitions();
+
+
+-- Upsert row into correct partition
+CREATE OR REPLACE FUNCTION stories_tags_map_partition_by_stories_id_insert_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_table_name TEXT;       -- partition table name (e.g. "stories_tags_map_01")
+BEGIN
+    SELECT stories_tags_map_get_partition_name( NEW.stories_id, 'stories_tags_map' ) INTO target_table_name;
+    EXECUTE '
+        INSERT INTO ' || target_table_name || '
+            SELECT $1.*
+        ON CONFLICT (stories_id, tags_id) DO NOTHING 
+        ' USING NEW;
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER stories_tags_map_partition_by_stories_id_insert_trigger
+    BEFORE INSERT ON stories_tags_map
+    FOR EACH ROW EXECUTE PROCEDURE stories_tags_map_partition_by_stories_id_insert_trigger();
+
+
+INSERT INTO stories_tags_map (stories_id, tags_id, db_row_last_updated)
+SELECT stories_id, tags_id, db_row_last_updated FROM stories_tags_map_old;
+
+DROP TABLE stories_tags_map_old;
+
+
+CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
+DECLARE
+    -- Database schema version number (same as a SVN revision number)
+    -- Increase it by 1 if you make major database schema changes.
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4642;
+
+BEGIN
+
+    -- Update / set database schema version
+    DELETE FROM database_variables WHERE name = 'database-schema-version';
+    INSERT INTO database_variables (name, value) VALUES ('database-schema-version', MEDIACLOUD_DATABASE_SCHEMA_VERSION::int);
+
+    return true;
+
+END;
+$$
+LANGUAGE 'plpgsql';
+
+--
+-- 2 of 2. Reset the database version.
+--
+SELECT set_database_schema_version();
+


### PR DESCRIPTION
**Problem:**

Primary key for `stories_tags_map` exceeded `INT`'s max. value; also, reindexing and readding foreign keys takes a lot of time.

**Solution:**

* Make primary key a `BIGINT`.
* Partition table to accommodate for further growth and make it easier to readd foreign keys.

Partitioning scheme closely follows what we have for `bitly_total_clicks`:

* `stories_tags_map` master table without no primary keys, foreign keys or indexes.
    * As the master table has no indexes, `ANALYZE SELECT ...` will print its intention to do a sequential scan over the table. No need to fear, the master table has no rows to scan.
* `stories_tags_map_partition_chunk_size()` function - returns 100m, this is how many `stories_id` chunks the table will be split into, i.e. stories with `0 <= stories_id < 100,000,000` will go into partition `stories_tags_map_00`, stories with `100,000,000 <= stories_id < 200,000,000` into partition `stories_tags_map_01`, ...
* `stories_tags_map_create_partitions()` - creates all the needed partitions for `MAX(stories_id) FROM stories` if they don't exist already; called in `mediawords.sql` and get called periodically in `create_missing_partitions()` (which, in turn, gets called by the `tools/db/create_missing_partitions.py` script).
* `stories_tags_map_partition_by_stories_id_insert_trigger()` trigger function - upserts entries into `stories_tags_map`, i.e. doesn't throw an exception if the tag mapping that is being INSERTed already exists.

**Misc.:**

* `table_exists()` now supports testing tables with schema prepended, e.g. `public.stories`.
