### PR TITLE
Python handler deproxy

### DIFF
--- a/lib/MediaWords/DB/HandlerProxy.pm
+++ b/lib/MediaWords/DB/HandlerProxy.pm
@@ -112,8 +112,10 @@ sub schema_is_up_to_date($)
 
     sub columns($)
     {
-        my $self           = shift;
-        my $return_value   = $self->{ _python_result }->columns();
+        my $self         = shift;
+        my $return_value = $self->{ _python_result }->columns();
+        return $return_value if MediaWords::Util::Python::called_from_python();
+
         my $writable_value = python_deep_copy( $return_value );
         return wantarray ? @{ $writable_value } : $writable_value;
     }
@@ -122,6 +124,8 @@ sub schema_is_up_to_date($)
     {
         my $self         = shift;
         my $return_value = $self->{ _python_result }->rows();
+        return $return_value if MediaWords::Util::Python::called_from_python();
+
         return python_deep_copy( $return_value );
     }
 
@@ -129,6 +133,8 @@ sub schema_is_up_to_date($)
     {
         my $self         = shift;
         my $return_value = $self->{ _python_result }->array();
+        return $return_value if MediaWords::Util::Python::called_from_python();
+
         return python_deep_copy( $return_value );
     }
 
@@ -136,21 +142,27 @@ sub schema_is_up_to_date($)
     {
         my $self         = shift;
         my $return_value = $self->{ _python_result }->hash();
+        return $return_value if MediaWords::Util::Python::called_from_python();
+
         return python_deep_copy( $return_value );
     }
 
     sub flat($)
     {
-        my $self           = shift;
-        my $return_value   = $self->{ _python_result }->flat();
+        my $self         = shift;
+        my $return_value = $self->{ _python_result }->flat();
+        return $return_value if MediaWords::Util::Python::called_from_python();
+
         my $writable_value = python_deep_copy( $return_value );
         return wantarray ? @{ $writable_value } : $writable_value;
     }
 
     sub hashes($)
     {
-        my $self           = shift;
-        my $return_value   = $self->{ _python_result }->hashes();
+        my $self         = shift;
+        my $return_value = $self->{ _python_result }->hashes();
+        return $return_value if MediaWords::Util::Python::called_from_python();
+
         my $writable_value = python_deep_copy( $return_value );
         return wantarray ? @{ $writable_value } : $writable_value;
     }
@@ -170,6 +182,8 @@ sub schema_is_up_to_date($)
         }
 
         my $return_value = $self->{ _python_result }->text( $text_type );
+        return $return_value if MediaWords::Util::Python::called_from_python();
+
         return python_deep_copy( $return_value );
     }
 
@@ -211,6 +225,8 @@ sub primary_key_column($$)
     }
 
     my $return_value = $self->{ _db }->primary_key_column( $table );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -230,6 +246,8 @@ sub find_by_id($$$)
     }
 
     my $return_value = $self->{ _db }->find_by_id( $table, $object_id );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -249,6 +267,8 @@ sub require_by_id($$$)
     }
 
     my $return_value = $self->{ _db }->require_by_id( $table, $object_id );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -325,6 +345,8 @@ sub insert($$$)
     }
 
     my $return_value = $self->{ _db }->insert( $table, $insert_hash );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -344,6 +366,8 @@ sub create($$$)
     }
 
     my $return_value = $self->{ _db }->create( $table, $insert_hash );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -363,6 +387,8 @@ sub find_or_create($$$)
     }
 
     my $return_value = $self->{ _db }->find_or_create( $table, $insert_hash );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -401,6 +427,8 @@ sub get_temporary_ids_table($$;$)
     }
 
     my $return_value = $self->{ _db }->get_temporary_ids_table( $ids, $ordered );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -443,6 +471,8 @@ sub quote($$)
     }
 
     my $return_value = $self->{ _db }->quote( $value );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -461,6 +491,8 @@ sub quote_bool($$)
     }
 
     my $return_value = $self->{ _db }->quote_bool( $value );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -479,6 +511,8 @@ sub quote_varchar($$)
     }
 
     my $return_value = $self->{ _db }->quote_varchar( $value );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -497,6 +531,8 @@ sub quote_date($$)
     }
 
     my $return_value = $self->{ _db }->quote_date( $value );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -515,6 +551,8 @@ sub quote_timestamp($$)
     }
 
     my $return_value = $self->{ _db }->quote_timestamp( $value );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 
@@ -630,6 +668,8 @@ sub copy_from($$)
     {
         my $self         = shift;
         my $return_value = $self->{ _python_result }->get_line();
+        return $return_value if MediaWords::Util::Python::called_from_python();
+
         return python_deep_copy( $return_value );
     }
 
@@ -685,6 +725,8 @@ sub attach_child_query($$$$$;$)
         $id_column,      #
         $single          #
     );
+    return $return_value if MediaWords::Util::Python::called_from_python();
+
     return python_deep_copy( $return_value );
 }
 

--- a/lib/MediaWords/DB/t/HandlerProxy.t
+++ b/lib/MediaWords/DB/t/HandlerProxy.t
@@ -11,9 +11,9 @@ use MediaWords::Test::DB;
 use MediaWords::Test::DB::HandlerProxy;
 
 # test whether calling hashes() or flat() returns a single row list or just the single value.
-sub test_single_row_list($)
+sub test_single_row_list()
 {
-    my ( $db ) = @_;
+    my $db = MediaWords::DB::connect_to_db( 'test' );
 
     my $hashes = MediaWords::Test::DB::HandlerProxy::get_single_row_hashes( $db );
 
@@ -23,19 +23,11 @@ sub test_single_row_list($)
 
     $r->[ 0 ]->{ foo } = 'bar';
     is( $r->[ 0 ]->{ foo }, 'bar', 'hashes results writeable' );
-
-}
-
-sub test_database($)
-{
-    my ( $db ) = @_;
-
-    test_single_row_list( $db );
 }
 
 sub main
 {
-    MediaWords::Test::DB::test_on_test_database( \&test_database );
+    test_single_row_list();
 }
 
 main();

--- a/lib/MediaWords/DB/t/HandlerProxy.t
+++ b/lib/MediaWords/DB/t/HandlerProxy.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+use Inline::Python;
+use Test::Deep;
+use Test::More tests => 2;
+
+use MediaWords::CommonLibs;
+
+use MediaWords::Test::DB;
+use MediaWords::Test::DB::HandlerProxy;
+
+# test whether calling hashes() or flat() returns a single row list or just the single value.
+sub test_single_row_list($)
+{
+    my ( $db ) = @_;
+
+    my $hashes = MediaWords::Test::DB::HandlerProxy::get_single_row_hashes( $db );
+
+    is( ref( $hashes ), ref( [] ), "hashes single row return type" );
+
+    my $r = $db->query( "select 'foo' as foo" )->hashes();
+
+    $r->[ 0 ]->{ foo } = 'bar';
+    is( $r->[ 0 ]->{ foo }, 'bar', 'hashes results writeable' );
+
+}
+
+sub test_database($)
+{
+    my ( $db ) = @_;
+
+    test_single_row_list( $db );
+}
+
+sub main
+{
+    MediaWords::Test::DB::test_on_test_database( \&test_database );
+}
+
+main();

--- a/lib/MediaWords/Test/DB/HandlerProxy.pm
+++ b/lib/MediaWords/Test/DB/HandlerProxy.pm
@@ -1,0 +1,11 @@
+package MediaWords::Test::DB::HandlerProxy;
+
+use strict;
+use warnings;
+
+use Modern::Perl "2015";
+use MediaWords::CommonLibs;    # set PYTHONPATH too
+
+import_python_module( __PACKAGE__, 'mediawords.test.db.handler_proxy' );
+
+1;

--- a/lib/MediaWords/Util/Python.pm
+++ b/lib/MediaWords/Util/Python.pm
@@ -249,4 +249,10 @@ sub normalize_boolean_for_db($;$)
     }
 }
 
+# return true if the caller is 'Inline::Python', which indicates the function was called from python
+sub called_from_python()
+{
+    return ( ( caller( 1 ) )[ 0 ] eq 'Inline::Python' );
+}
+
 1;

--- a/mediacloud/mediawords/test/db/handler_proxy.py
+++ b/mediacloud/mediawords/test/db/handler_proxy.py
@@ -1,0 +1,11 @@
+"""Python defined functions for use in MediaWords/DB/t/HandlerProxy.t tests."""
+
+from mediawords.db import DatabaseHandler
+
+
+def get_single_row_hashes(db: DatabaseHandler) -> list:
+    """Return a single row result from db.query().hashes().
+
+    This is to test from perl the result of a python query call when called using a perl HandlerProxy object.
+    """
+    return db.query("select 'foo' as foo").hashes()

--- a/mediacloud/mediawords/tm/fetch_link.py
+++ b/mediacloud/mediawords/tm/fetch_link.py
@@ -172,9 +172,6 @@ def get_failed_urls(db: DatabaseHandler, topic: dict, urls: list) -> list:
             'd': urls
         }).hashes()
 
-    if r is None:
-        return []
-
     failed_urls = [u['url'] for u in r]
 
     return failed_urls

--- a/t/test_tm_mine.t
+++ b/t/test_tm_mine.t
@@ -29,9 +29,9 @@ use MediaWords::Util::Web;
 
 Readonly my $BASE_PORT => 8890;
 
-Readonly my $NUM_SITES          => 20;
-Readonly my $NUM_PAGES_PER_SITE => 20;
-Readonly my $NUM_LINKS_PER_PAGE => 5;
+Readonly my $NUM_SITES          => 5;
+Readonly my $NUM_PAGES_PER_SITE => 10;
+Readonly my $NUM_LINKS_PER_PAGE => 2;
 
 Readonly my $TOPIC_PATTERN => 'FOOBARBAZ';
 


### PR DESCRIPTION
Substantive comments copied from first commit below.  I'm going to go ahead and merge this once it passes the test suite because it is causing topic blocking bugs in production.  But I'm eager for a review for how this impacts the database handling and proxying.

Don't deep_copy or wantarray return value in HandlerProxy if the caller is python

When a database handle was created in perl and passed to python, the hashes() and flat() methods were returning the single value rather than a list in python when the query returned only one row.  This is different than the behavior when calling those functions from a python created db handle, so it was causing intermittent havoc in python functions called from perl with a perl db handle.  The cause was that those methods were calling wantarray in perl to figure out whether to return a list or a ref to a list, which was causing the return type confusion.

You can reproduce this issue by uncommenting the new code in HandlerProxy hashes() and running lib/MediaWords/DB/t/HandlerProxy.t

In the theory of reducing unnecessary work and round trip complexity, I added a check to all of the deep_copy( $return_value ) calls in HandlerProxy.pm to avoid the deep_copy if the caller is python.

