### PR TITLE
Install pkg-config for CyHunspell to be able to find Hunspell

### DIFF
--- a/ansible/roles/system-packages/tasks/main-Ubuntu.yml
+++ b/ansible/roles/system-packages/tasks/main-Ubuntu.yml
@@ -92,6 +92,7 @@
     - graphviz-dev
     - hunspell
     - libexpat1-dev
+    - libhunspell-dev
     - libmecab-dev
     - libgraphviz-dev
     - libtidy-dev
@@ -108,6 +109,7 @@
     - mecab-ipadic-neologd
     - netcat
     - openjdk-8-jdk
+    - pkg-config
     - python-pip
     - python2.7
     - python2.7-dev


### PR DESCRIPTION
CyHunspell, Hindi's stemming dependency, depends on Hunspell which it
tries to find using pkg-config. If it fails to find it, CyHunspell's
installer tries to download and compile Hunspell package from
SourceForge. downloads.sourceforge.org gets constantly down recently and
so some of the CI runs fail just because of that.