### PR TITLE
Speed up sentence field count

### DIFF
--- a/doc/api_2_0_spec/api_2_0_spec.md
+++ b/doc/api_2_0_spec/api_2_0_spec.md
@@ -849,12 +849,11 @@ are currently `tags_id_stories`.
 | `fq`            | `null`            | `fq` ("filter query") parameter which is passed directly to Solr
 | `sample_size`   | 1000              | number of sentences to sample, max 100,000
 | `include_stats` | 0                 | include stats about the request as a whole
-| `field`         | `tags_id_stories` | field to count
 | `tag_sets_id`   | `null`            | return only tags belonging to the given tag set
 
 See above /api/v2/stories_public/list for Solr query syntax.
 
-If the field is set to `tags_id_stories`, the call returns all of the tags associated with
+The call returns all of the tags associated with
 story including a sentence matching the query along with a count of how many times each tag is associated with
 each matching story.
 

--- a/lib/MediaWords/Controller/Api/V2/Sentences.pm
+++ b/lib/MediaWords/Controller/Api/V2/Sentences.pm
@@ -303,14 +303,17 @@ sub field_count_GET
 {
     my ( $self, $c ) = @_;
 
-    if ( $c->req->params->{ sample_size } && ( $c->req->params->{ sample_size } > 100_000 ) )
-    {
-        $c->req->params->{ sample_size } = 100_000;
-    }
+    my $db     = $c->dbis;
+    my $params = $c->req->params;
 
-    my $fc = MediaWords::Solr::SentenceFieldCounts->new( { db => $c->dbis, cgi_params => $c->req->params } );
-
-    my $counts = $fc->get_counts;
+    my $counts = MediaWords::Solr::SentenceFieldCounts::get_counts(
+        $db,                           #
+        $params->{ q },                #
+        $params->{ fq },               #
+        $params->{ sample_size },      #
+        $params->{ tag_sets_id },      #
+        $params->{ include_stats },    #
+    );
 
     $self->status_ok( $c, entity => $counts );
 }

--- a/lib/MediaWords/Solr/SentenceFieldCounts.pm
+++ b/lib/MediaWords/Solr/SentenceFieldCounts.pm
@@ -1,155 +1,87 @@
 package MediaWords::Solr::SentenceFieldCounts;
 
-use Moose;
-
-# return counts of how many sentences match any of the following fields:
-# media_id, language,
-
 use strict;
 use warnings;
 
-use CHI;
-use Data::Dumper;
-
+use MediaWords::CommonLibs;
 use MediaWords::Solr;
-use MediaWords::Util::Config;
 
-# Moose instance fields
+use Data::Dumper;
+use List::Util qw/min/;
 
-has 'q'             => ( is => 'rw', isa => 'Str' );
-has 'fq'            => ( is => 'rw', isa => 'ArrayRef' );
-has 'sample_size'   => ( is => 'rw', isa => 'Int', default => 1000 );
-has 'field'         => ( is => 'rw', isa => 'Str', default => 'tags_id_stories' );
-has 'tag_sets_id'   => ( is => 'rw', isa => 'Int' );
-has 'include_stats' => ( is => 'rw', isa => 'Bool' );
-has 'db' => ( is => 'rw' );
-
-# list of all attribute names that should be exposed as cgi params
-sub _get_cgi_param_attributes()
+# perform the solr query and collect the sentence ids.  query postgres for the sentences and associated tags
+# and return counts for each of the following fields:
+# publish_day, media_id, language, sentence_tags_id, media_tags_id, story_tags_id
+sub get_counts($;$$$$$)
 {
-    return [ qw(q fq sample_size include_stats field tag_sets_id) ];
-}
+    my ( $db, $q, $fq, $sample_size, $tag_sets_id, $include_stats ) = @_;
 
-# add support for constructor in this form:
-#   WordsCounts->new( cgi_params => $cgi_params )
-# where $cgi_params is a hash of cgi params directly from a web request
-around BUILDARGS => sub {
-    my $orig  = shift;
-    my $class = shift;
-
-    my $args;
-    if ( ref( $_[ 0 ] ) )
+    if ( $fq and !ref( $fq ) )
     {
-        $args = $_[ 0 ];
-    }
-    elsif ( defined( $_[ 0 ] ) )
-    {
-        $args = { @_ };
-    }
-    else
-    {
-        $args = {};
+        $fq = [ $fq ];
     }
 
-    my $vals;
-    if ( $args->{ cgi_params } )
-    {
-        my $cgi_params = $args->{ cgi_params };
+    $fq ||= [];
+    $sample_size ||= 1000;
+    $tag_sets_id += 0;
 
-        $vals = {};
-        my $keys = _get_cgi_param_attributes();
-        for my $key ( @{ $keys } )
-        {
-            $vals->{ $key } = $cgi_params->{ $key } if ( exists( $cgi_params->{ $key } ) );
-        }
+    $sample_size = min( $sample_size, 100_000 );
 
-        $vals->{ db } = $args->{ db } if ( $args->{ db } );
-    }
-    else
+    unless ( $q or ( $fq && @{ $fq } ) )
     {
-        $vals = $args;
+        return [];
     }
 
-    $vals->{ fq } = [ $vals->{ fq } ] if ( $vals->{ fq } && !ref( $vals->{ fq } ) );
-    $vals->{ fq } ||= [];
+    my $solr_params = {
+        q    => $q,
+        fq   => $fq,
+        rows => $sample_size,
+        fl   => 'stories_id',
+        sort => 'random_1 asc',
+    };
 
-    return $class->$orig( $vals );
-};
+    my $data = MediaWords::Solr::query( $db, $solr_params );
 
-# given the list of ids, get the counts for the various related fields
-sub _get_postgresql_counts
-{
-    my ( $self, $ids ) = @_;
+    my $sentences_found = $data->{ response }->{ numFound };
+    my $ids = [ map { int( $_->{ 'stories_id' } ) } @{ $data->{ response }->{ docs } } ];
 
-    my $tag_set_clause = $self->tag_sets_id ? "AND t.tag_sets_id = " . ( $self->tag_sets_id + 0 ) : '';
+    my $tag_set_clause = $tag_sets_id ? "AND t.tag_sets_id = $tag_sets_id" : '';
 
     $ids = [ map { int( $_ ) } @{ $ids } ];
 
-    my $ids_table = $self->db->get_temporary_ids_table( $ids );
+    my $ids_table = $db->get_temporary_ids_table( $ids );
 
-    my $counts = $self->db->query( <<SQL )->hashes;
+    my $counts = $db->query(
+        <<SQL
         SELECT
             COUNT(*) AS count,
             t.tags_id AS tags_id,
             t.tag,
             t.label,
             t.tag_sets_id
-        FROM stories_tags_map AS m
+        FROM stories_tags_map AS stm
             JOIN tags AS t ON (
-                m.tags_id = t.tags_id
+                stm.tags_id = t.tags_id
                 $tag_set_clause
             )
-        WHERE m.stories_id IN (
+        WHERE stm.stories_id IN (
             SELECT id
             FROM $ids_table
         )
         GROUP BY t.tags_id
         ORDER BY COUNT(*) DESC
 SQL
+    )->hashes;
 
-    return $counts;
-}
-
-# perform the solr query and collect the sentence ids.  query postgres for the sentences and associated tags
-# and return counts for each of the following fields:
-# publish_day, media_id, language, sentence_tags_id, media_tags_id, story_tags_id
-sub get_counts
-{
-    my ( $self ) = @_;
-
-    unless ( $self->{ field } eq 'tags_id_stories' )
-    {
-        die "Unknown field: " . $self->{ field };
-    }
-
-    return [] unless ( $self->q() || ( $self->fq && @{ $self->fq } ) );
-
-    my $start_generation_time = time();
-
-    my $solr_params = {
-        q    => $self->q(),
-        fq   => $self->fq,
-        rows => $self->sample_size,
-        fl   => 'stories_id',
-        sort => 'random_1 asc'
-    };
-
-    my $data = MediaWords::Solr::query( $self->db, $solr_params );
-
-    my $sentences_found = $data->{ response }->{ numFound };
-    my $ids = [ map { int( $_->{ 'stories_id' } ) } @{ $data->{ response }->{ docs } } ];
-
-    my $counts = $self->_get_postgresql_counts( $ids );
-
-    if ( $self->include_stats )
+    if ( $include_stats )
     {
         return {
             stats => {
                 num_sentences_returned => scalar( @{ $ids } ),
                 num_sentences_found    => $sentences_found,
-                sample_size_param      => $self->sample_size
+                sample_size_param      => $sample_size,
             },
-            counts => $counts
+            counts => $counts,
         };
     }
     else


### PR DESCRIPTION
I've sped up the SQL query that does the tag matching -- apparently, fetching a list of tags for stories and filtering afterwards by tag set's ID is way faster (see ea81babc0e01991e7f1f367102c0bea42cb47c09).

Before: https://explain.depesz.com/s/6SAr -- 26.9 s; every `stories_tags_map` partition gets scanned a whopping 585,900 times (651 for all tags under tag set, times 900 for (probably) story ID count).

After: https://explain.depesz.com/s/x1Hx -- 0.5 s; every `stories_tags_map` partition gets queried for story IDs only; tag set filtering is done afterwards.

Also removed a bunch of dead / nonworking code and simplified parameters.

Fixes #360.