### PR TITLE
Add INSERT trigger on story_sentences_partitioned; change order of triggers so that last_updated_trigger() fires first

### DIFF
--- a/schema/migrations/mediawords-4675-4676.sql
+++ b/schema/migrations/mediawords-4675-4676.sql
@@ -1,0 +1,146 @@
+--
+-- This is a Media Cloud PostgreSQL schema difference file (a "diff") between schema
+-- versions 4675 and 4676.
+--
+-- If you are running Media Cloud with a database that was set up with a schema version
+-- 4675, and you would like to upgrade both the Media Cloud and the
+-- database to be at version 4676, import this SQL file:
+--
+--     psql mediacloud < mediawords-4675-4676.sql
+--
+-- You might need to import some additional schema diff files to reach the desired version.
+--
+
+--
+-- 1 of 2. Import the output of 'apgdiff':
+--
+
+SET search_path = public, pg_catalog;
+
+
+DROP TRIGGER story_sentences_partitioned_last_updated_trigger ON story_sentences_partitioned;
+
+
+CREATE TRIGGER story_sentences_partitioned_00_last_updated_trigger
+    BEFORE INSERT OR UPDATE ON story_sentences_partitioned
+    FOR EACH ROW
+    EXECUTE PROCEDURE last_updated_trigger();
+
+
+-- Note: "INSERT ... RETURNING *" doesn't work with the trigger, please use
+-- "story_sentences" view instead
+CREATE OR REPLACE FUNCTION story_sentences_partitioned_insert_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_table_name TEXT;       -- partition table name (e.g. "stories_tags_map_01")
+BEGIN
+    SELECT stories_partition_name('story_sentences_partitioned', NEW.stories_id ) INTO target_table_name;
+    EXECUTE '
+        INSERT INTO ' || target_table_name || '
+            SELECT $1.*
+        ' USING NEW;
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER story_sentences_partitioned_01_insert_trigger
+    BEFORE INSERT ON story_sentences_partitioned
+    FOR EACH ROW
+    EXECUTE PROCEDURE story_sentences_partitioned_insert_trigger();
+
+
+CREATE OR REPLACE FUNCTION story_sentences_view_insert_update_delete() RETURNS trigger AS $$
+
+DECLARE
+    target_table_name TEXT;       -- partition table name (e.g. "story_sentences_01")
+
+BEGIN
+
+    IF (TG_OP = 'INSERT') THEN
+
+        -- All new INSERTs go to partitioned table only.
+        --
+        -- By INSERTing into the master table, we're letting triggers choose
+        -- the correct partition and update db_row_last_updated.
+        INSERT INTO story_sentences_partitioned SELECT NEW.*;
+
+        RETURN NEW;
+
+    ELSIF (TG_OP = 'UPDATE') THEN
+
+        -- UPDATE on both tables
+
+        UPDATE story_sentences_partitioned
+            SET stories_id = NEW.stories_id,
+                sentence_number = NEW.sentence_number,
+                sentence = NEW.sentence,
+                media_id = NEW.media_id,
+                publish_date = NEW.publish_date,
+                db_row_last_updated = NEW.db_row_last_updated,
+                language = NEW.language,
+                is_dup = NEW.is_dup
+            WHERE stories_id = OLD.stories_id
+              AND sentence_number = OLD.sentence_number;
+
+        UPDATE story_sentences_nonpartitioned
+            SET stories_id = NEW.stories_id,
+                sentence_number = NEW.sentence_number,
+                sentence = NEW.sentence,
+                media_id = NEW.media_id,
+                publish_date = NEW.publish_date,
+                db_row_last_updated = NEW.db_row_last_updated,
+                language = NEW.language,
+                is_dup = NEW.is_dup
+            WHERE stories_id = OLD.stories_id
+              AND sentence_number = OLD.sentence_number;
+
+        RETURN NEW;
+
+    ELSIF (TG_OP = 'DELETE') THEN
+
+        -- DELETE from both tables
+
+        DELETE FROM story_sentences_partitioned
+            WHERE stories_id = OLD.stories_id
+              AND sentence_number = OLD.sentence_number;
+
+        DELETE FROM story_sentences_nonpartitioned
+            WHERE stories_id = OLD.stories_id
+              AND sentence_number = OLD.sentence_number;
+
+        -- Return deleted rows
+        RETURN OLD;
+
+    ELSE
+        RAISE EXCEPTION 'Unconfigured operation: %', TG_OP;
+
+    END IF;
+
+END;
+$$ LANGUAGE plpgsql;
+
+
+--
+-- 2 of 2. Reset the database version.
+--
+
+CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
+DECLARE
+    -- Database schema version number (same as a SVN revision number)
+    -- Increase it by 1 if you make major database schema changes.
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4676;
+
+BEGIN
+
+    -- Update / set database schema version
+    DELETE FROM database_variables WHERE name = 'database-schema-version';
+    INSERT INTO database_variables (name, value) VALUES ('database-schema-version', MEDIACLOUD_DATABASE_SCHEMA_VERSION::int);
+
+    return true;
+
+END;
+$$
+LANGUAGE 'plpgsql';
+
+SELECT set_database_schema_version();


### PR DESCRIPTION
* A trigger on the intermediary `story_sentences_view_insert_update_delete` view was
INSERTing new sentences directly into the partitions and serving as a
INSERT trigger on `story_sentences_partitioned` itself. This behavior
was not firing `last_updated_trigger()` on
`story_sentences_partitioned` base table. The trigger on the view will
now INSERT into `story_sentences_partitioned` base table,
letting it choose which partition to write the row to and which triggers to fire.

* Added INSERT trigger on `story_sentences_partitioned` which didn't
exist before (because it didn't have to -- no one was supposed to use
`story_sentences_partitioned` directly, all the operations were to be
done on the `story_sentences` intermediary view).

* Changed order of `BEFORE` triggers on `story_sentences_partitioned` by
renaming them. When multiple triggers are to be fired for the specific
event on a table, PostgreSQL runs them in an alphabetical order.
`last_updated_trigger` (starting with an "l") has to fire before
`insert_trigger`, so the triggers have been renamed to
`00_last_updated_trigger` and `01_insert_trigger`.