### PR TITLE
fix media_normalized_urls update performance

### DIFF
--- a/mediacloud/mediawords/tm/media.py
+++ b/mediacloud/mediawords/tm/media.py
@@ -5,7 +5,7 @@ import time
 import typing
 
 from mediawords.db import DatabaseHandler
-import mediawords.db.locks
+from mediawords.db.locks import get_session_lock
 from mediawords.util.log import create_logger
 import mediawords.util.url
 
@@ -123,10 +123,18 @@ def _update_media_normalized_urls(db: DatabaseHandler) -> None:
     if not _normalized_urls_out_of_date(db):
         return
 
-    # put a lock on this because the process of generating all media urls will take around 30 seconds, and we don't
+    # put a lock on this because the process of generating all media urls will take a couple hours, and we don't
     # want all workers to do the work
-    db.begin()
-    mediawords.db.locks.get_session_lock(db, 'MediaWords::TM::Media::media_normalized_urls', 1, wait=True)
+    locked = False
+    while not locked:
+        db.begin()
+        # poll instead of block so that we can releae the transaction and see whether someone else has already
+        # updated all of the media
+        locked = get_session_lock(db, 'MediaWords::TM::Media::media_normalized_urls', 1, wait=False)
+        if not locked:
+            db.commit()
+            log.info("sleeping for media_normalized_urls lock...")
+            time.sleep(1)
 
     if not _normalized_urls_out_of_date(db):
         db.commit()
@@ -152,7 +160,7 @@ def _update_media_normalized_urls(db: DatabaseHandler) -> None:
     total = len(media)
     for medium in media:
         i += 1
-        normalized_url = mediawords.util.url.normalize_url_lossy(medium['url'])
+        normalized_url = mediawords.util.url.normalize_url_lossy_no_decode(medium['url'])
         if normalized_url is None:
             normalized_url = medium['url']
 

--- a/mediacloud/mediawords/util/url/__init__.py
+++ b/mediacloud/mediawords/util/url/__init__.py
@@ -37,11 +37,18 @@ __HOMEPAGE_URL_PATH_REGEXES = [
 ]
 
 
-# noinspection SpellCheckingInspection
 def fix_common_url_mistakes(url: str) -> Optional[str]:
     """Fixes common URL mistakes (mistypes, etc.)."""
     url = decode_object_from_bytes_if_needed(url)
 
+    return fix_common_url_mistakes_no_decode(url)
+
+
+# noinspection SpellCheckingInspection
+def fix_common_url_mistakes_no_decode(url: str) -> Optional[str]:
+    """Fixes common URL mistakes (mistypes, etc.).
+
+    Don't decode_object_from_bytes.  Only safe to call from python."""
     if url is None:
         return None
 
@@ -334,16 +341,21 @@ def normalize_url_lossy(url: str) -> Optional[str]:
     See also normalize_url_lossy_version() above.
     """
     url = decode_object_from_bytes_if_needed(url)
+
+    return normalize_url_lossy_no_decode(url)
+
+
+# noinspection SpellCheckingInspection
+def normalize_url_lossy_no_decode(url: str) -> Optional[str]:
+    """Implement normalize_url_lossy as described above without calling decode_object_from_bytes_if_needed.
+
+    Only call directly from python."""
     if url is None:
         return None
     if len(url) == 0:
         return None
 
-    url = fix_common_url_mistakes(url)
-
-    if not is_http_url(url):
-        log.warning("URL is not HTTP(s): %s" % url)
-        return url
+    url = fix_common_url_mistakes_no_decode(url)
 
     url = url.lower()
 
@@ -373,7 +385,7 @@ def normalize_url_lossy(url: str) -> Optional[str]:
     # canonical_url might raise an encoding error if url is not invalid; just skip the canonical url step in the case
     # noinspection PyBroadException
     try:
-        url = canonical_url(url)
+        url = url_normalize.url_normalize(url)
     except Exception as ex:
         log.warning("Unable to get canonical URL for URL %s: %s" % (url, str(ex),))
 


### PR DESCRIPTION
This fixes #422.

The most important thing this does is fix a bug that was causing the media_normalized_urls table to get updated many times each time the media table was updated.  This is because we were starting a transaction and than waiting for an advisory lock within the transaction.  This means that the code that was detected whether the media_normalized_urls table had been updated to reflect he latest media rows was seeing the old transaction data from when the lock get was initially tried.  This code changes the get_session_lock call not to wait for the lock so that we can poll and start a new transaction each time we try again for the lock (making the updated media rows from any other workers visible).

I also did some work to speed up the normalize_url_lossy() call just to reduce the overall lock contention when an update is needed.  The changes avoid calling decoded_from_bytes_if_needed() when not necessary and also avoid calling redundant code in canonical_url() and normalize_url_lossy().  The resulting code is about 17x faster and reduces the time to normalize the media table from more than a day to a couple of hours.

I'm going to go ahead and merge and deploy this because our researchers are actively waiting for some topics to run that have been blocked by this issue.