### PR TITLE
Speed up decode_object_from_bytes_if_needed() and some other functions by 100x

### DIFF
--- a/mediacloud/mediawords/tm/media.py
+++ b/mediacloud/mediawords/tm/media.py
@@ -160,7 +160,7 @@ def _update_media_normalized_urls(db: DatabaseHandler) -> None:
     total = len(media)
     for medium in media:
         i += 1
-        normalized_url = mediawords.util.url.normalize_url_lossy_no_decode(medium['url'])
+        normalized_url = mediawords.util.url.normalize_url_lossy(medium['url'])
         if normalized_url is None:
             normalized_url = medium['url']
 

--- a/mediacloud/mediawords/util/config.py
+++ b/mediacloud/mediawords/util/config.py
@@ -56,30 +56,31 @@ def set_config_file(config_file: str) -> None:
     set_config(__parse_yaml(config_file))
 
 
+def __merge_configs_internal(a: dict, b: dict, path=None) -> dict:
+    """Merges b into a (http://stackoverflow.com/a/7205107/200603)"""
+    if path is None:
+        path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                __merge_configs_internal(a[key], b[key], path + [str(key)])
+            elif a[key] == b[key]:
+                pass  # same leaf value
+            else:
+                log.debug(
+                    "Overwriting '%(key)s' default value '%(default_value)s' with custom '%(custom_value)s" % {
+                        'key': key,
+                        'default_value': a[key],
+                        'custom_value': b[key]
+                    })
+                a[key] = b[key]
+        else:
+            a[key] = b[key]
+    return a
+
+
 def __merge_configs(config: dict, static_defaults: dict) -> dict:
     """Merge configs with precedence for the mediawords.yml config."""
-
-    def __merge_configs_internal(a: dict, b: dict, path=None) -> dict:
-        """Merges b into a (http://stackoverflow.com/a/7205107/200603)"""
-        if path is None:
-            path = []
-        for key in b:
-            if key in a:
-                if isinstance(a[key], dict) and isinstance(b[key], dict):
-                    __merge_configs_internal(a[key], b[key], path + [str(key)])
-                elif a[key] == b[key]:
-                    pass  # same leaf value
-                else:
-                    log.debug(
-                        "Overwriting '%(key)s' default value '%(default_value)s' with custom '%(custom_value)s" % {
-                            'key': key,
-                            'default_value': a[key],
-                            'custom_value': b[key]
-                        })
-                    a[key] = b[key]
-            else:
-                a[key] = b[key]
-        return a
 
     merged_config = static_defaults.copy()
     merged_config = __merge_configs_internal(merged_config, config)

--- a/mediacloud/mediawords/util/html.py
+++ b/mediacloud/mediawords/util/html.py
@@ -13,7 +13,7 @@ from mediawords.util.url import is_http_url
 log = create_logger(__name__)
 
 
-def link_canonical_url_from_html(html: str, base_url: Optional[str]= None) -> Optional[str]:
+def link_canonical_url_from_html(html: str, base_url: Optional[str] = None) -> Optional[str]:
     """From the provided HTML, determine the <link rel="canonical" /> URL (if any)."""
     html = str(decode_object_from_bytes_if_needed(html))
 
@@ -40,43 +40,45 @@ def link_canonical_url_from_html(html: str, base_url: Optional[str]= None) -> Op
     return None
 
 
-def meta_refresh_url_from_html(html: str, base_url: Optional[str] = None) -> Optional[str]:
-    """From the provided HTML, determine the <meta http-equiv="refresh" /> URL (if any)."""
-    def __get_meta_refresh_url_from_tag(inner_tag: str, inner_base_url: Optional[str]=None) -> Optional[str]:
-        """Given a <meta ...> tag, return the url from the content="url=XXX" attribute.
+def __get_meta_refresh_url_from_tag(inner_tag: str, inner_base_url: Optional[str] = None) -> Optional[str]:
+    """Given a <meta ...> tag, return the url from the content="url=XXX" attribute.
 
-        Return None if no such url isfound.
-        """
-        if not re.search(r'http-equiv\s*?=\s*?["\']\s*?refresh\s*?["\']', inner_tag, re.I):
-            return None
+    Return None if no such url isfound.
+    """
+    if not re.search(r'http-equiv\s*?=\s*?["\']\s*?refresh\s*?["\']', inner_tag, re.I):
+        return None
 
+    # content="url='http://foo.bar'"
+    inner_url = None
+
+    match = re.search(r'content\s*?=\s*?"\d*?\s*?;?\s*?URL\s*?=\s*?\'(.+?)\'', inner_tag, re.I)
+    if match:
+        inner_url = match.group(1)
+    else:
         # content="url='http://foo.bar'"
-        inner_url = None
-
-        match = re.search(r'content\s*?=\s*?"\d*?\s*?;?\s*?URL\s*?=\s*?\'(.+?)\'', inner_tag, re.I)
+        match = re.search(r'content\s*?=\s*?\'\d*?\s*?;?\s*?URL\s*?=\s*?"(.+?)"', inner_tag, re.I)
         if match:
             inner_url = match.group(1)
         else:
-            # content="url='http://foo.bar'"
-            match = re.search(r'content\s*?=\s*?\'\d*?\s*?;?\s*?URL\s*?=\s*?"(.+?)"', inner_tag, re.I)
+            # Fallback
+            match = re.search(r'content\s*?=\s*?["\']\d*?\s*?;?\s*?URL\s*?=\s*?(.+?)["\']', inner_tag, re.I)
             if match:
                 inner_url = match.group(1)
-            else:
-                # Fallback
-                match = re.search(r'content\s*?=\s*?["\']\d*?\s*?;?\s*?URL\s*?=\s*?(.+?)["\']', inner_tag, re.I)
-                if match:
-                    inner_url = match.group(1)
 
-        if inner_url is None:
-            return None
-
-        if is_http_url(inner_url):
-            return inner_url
-
-        if inner_base_url is not None:
-            return urljoin(base=str(inner_base_url), url=inner_url)
-
+    if inner_url is None:
         return None
+
+    if is_http_url(inner_url):
+        return inner_url
+
+    if inner_base_url is not None:
+        return urljoin(base=str(inner_base_url), url=inner_url)
+
+    return None
+
+
+def meta_refresh_url_from_html(html: str, base_url: Optional[str] = None) -> Optional[str]:
+    """From the provided HTML, determine the <meta http-equiv="refresh" /> URL (if any)."""
 
     html = str(decode_object_from_bytes_if_needed(html))
     base_url_decode = decode_object_from_bytes_if_needed(base_url)
@@ -121,7 +123,7 @@ def _sententize_block_level_tags(s: str) -> str:
     return s
 
 
-def html_strip(s: str, include_title: bool=False) -> str:
+def html_strip(s: str, include_title: bool = False) -> str:
     """Strip the html tags, html comments, any any text within TITLE, SCRIPT, APPLET, OBJECT, and STYLE tags.
 
     Derived from code by powerman from: http://www.perlmonks.org/?node_id=161281.
@@ -153,7 +155,7 @@ def html_strip(s: str, include_title: bool=False) -> str:
     return text.strip()
 
 
-def html_title(html: str, fallback: str, trim_to_length: int=0) -> Optional[str]:
+def html_title(html: str, fallback: str, trim_to_length: int = 0) -> Optional[str]:
     """Parse the content for tags that might indicate the story's title.
 
     Arguments:

--- a/mediacloud/mediawords/util/perl.py
+++ b/mediacloud/mediawords/util/perl.py
@@ -59,96 +59,97 @@ class McConvertDBDPgArgumentsToPsycopg2FormatException(Exception):
     pass
 
 
+def __replace_double_question_marks_or_return_none(q: str, q_args: list) -> Union[tuple, None]:
+    """Replace "??" parameters with psycopg2's "%s" and tuple parameter, or return None if not found."""
+
+    double_question_mark_regex = re.compile("""
+        (?P<in_statement>\sIN\s)    # "(WHERE) column IN"
+        \(\s*\?\?\s*\)              # "(??)" with optional spaces around
+    """, flags=re.I | re.X)
+    double_question_mark_replacement = r'\g<in_statement>%s'
+
+    double_question_mark_count = len(re.findall(double_question_mark_regex, q))
+    if double_question_mark_count > 0:
+        if double_question_mark_count > 1:
+            raise McConvertDBDPgArgumentsToPsycopg2FormatException("""
+                More than one double question mark found
+                in query "%(query)s" (arguments: %(query_args)s)
+            """ % {
+                'query': q,
+                'query_args': q_args,
+            })
+
+        q = re.sub(double_question_mark_regex, double_question_mark_replacement, q)
+
+        if not isinstance(q_args, tuple):  # might have been converted previously
+            # Convert arguments to first (and only) psycopg2's query parameter
+            # (which should be a tuple: http://stackoverflow.com/a/28117658/200603)
+            q_args = tuple(q_args)
+            q_args = (q_args,)
+
+        return q, q_args
+
+    else:
+        return None
+
+
+def __replace_question_marks_or_return_none(q: str, q_args: list) -> Union[tuple, None]:
+    """Replace "?" parameters with psycopg2's "%s", or return None if not found."""
+
+    question_mark_regex = re.compile("""
+        (?P<char_before_question_mark>\s|,|\()      # Question mark preceded by whitespace, comma or bracket
+        \?                                          # Question mark
+        (?=(\s|,|\)|(::)|$))                        # Lookahead and make sure question mark is singled out
+    """, flags=re.I | re.X)
+    question_mark_replacement = r'\g<char_before_question_mark>%s'
+
+    question_mark_count = len(re.findall(question_mark_regex, q))
+    if question_mark_count > 0:
+
+        q = re.sub(question_mark_regex, question_mark_replacement, q)
+
+        # Convert arguments to psycopg2's argument tuple
+        if not isinstance(q_args, tuple):  # might have been converted previously
+            q_args = tuple(q_args)
+
+        return q, q_args
+
+    else:
+        return None
+
+
+def __replace_dollar_signs_or_return_none(q: str, q_args: list) -> Union[tuple, None]:
+    """Replace "$1" parameters with psycopg2's "%(param_1)s", or return None if not found."""
+
+    dollar_sign_regex = re.compile("""
+        (?P<char_before_dollar_sign>\s|,|\()    # Dollar sign preceded by whitespace, comma or bracket
+        \$(?P<param_index>\d)                   # Dollar sign with a single-digit index ("$1", "$2", ...)
+        (?=(\s|,|\)|(::)|$))                    # Lookahead and make sure dollar sign is singled out
+    """, flags=re.I | re.X)
+    dollar_sign_replacement = r'\g<char_before_dollar_sign>%(param_\g<param_index>)s'
+
+    dollar_sign_unique_indexes = set([x[1] for x in re.findall(dollar_sign_regex, q)])
+    dollar_sign_unique_count = len(dollar_sign_unique_indexes)
+    if dollar_sign_unique_count > 0:
+
+        q = re.sub(dollar_sign_regex, dollar_sign_replacement, q)
+
+        # Convert arguments to psycopg2's argument dictionary
+        if not isinstance(q_args, dict):  # might have been converted previously
+            q_args_dict = {}
+            for i in range(0, len(q_args)):
+                q_args_dict['param_%d' % (i + 1)] = q_args[i]
+            q_args = q_args_dict
+
+        return q, q_args
+
+    else:
+        return None
+
+
 # MC_REWRITE_TO_PYTHON: remove after porting queries to named parameter style
 def convert_dbd_pg_arguments_to_psycopg2_format(*query_parameters: Union[list, tuple], skip_decoding=False) -> tuple:
     """Convert DBD::Pg's question mark-style SQL query parameters to psycopg2's syntax."""
-
-    def __replace_double_question_marks_or_return_none(q: str, q_args: list) -> Union[tuple, None]:
-        """Replace "??" parameters with psycopg2's "%s" and tuple parameter, or return None if not found."""
-
-        double_question_mark_regex = re.compile("""
-            (?P<in_statement>\sIN\s)    # "(WHERE) column IN"
-            \(\s*\?\?\s*\)              # "(??)" with optional spaces around
-        """, flags=re.I | re.X)
-        double_question_mark_replacement = r'\g<in_statement>%s'
-
-        double_question_mark_count = len(re.findall(double_question_mark_regex, q))
-        if double_question_mark_count > 0:
-            if double_question_mark_count > 1:
-                raise McConvertDBDPgArgumentsToPsycopg2FormatException("""
-                    More than one double question mark found
-                    in query "%(query)s" (arguments: %(query_args)s)
-                """ % {
-                    'query': q,
-                    'query_args': q_args,
-                })
-
-            q = re.sub(double_question_mark_regex, double_question_mark_replacement, q)
-
-            if not isinstance(q_args, tuple):  # might have been converted previously
-                # Convert arguments to first (and only) psycopg2's query parameter
-                # (which should be a tuple: http://stackoverflow.com/a/28117658/200603)
-                q_args = tuple(q_args)
-                q_args = (q_args,)
-
-            return q, q_args
-
-        else:
-            return None
-
-    def __replace_question_marks_or_return_none(q: str, q_args: list) -> Union[tuple, None]:
-        """Replace "?" parameters with psycopg2's "%s", or return None if not found."""
-
-        question_mark_regex = re.compile("""
-            (?P<char_before_question_mark>\s|,|\()      # Question mark preceded by whitespace, comma or bracket
-            \?                                          # Question mark
-            (?=(\s|,|\)|(::)|$))                        # Lookahead and make sure question mark is singled out
-        """, flags=re.I | re.X)
-        question_mark_replacement = r'\g<char_before_question_mark>%s'
-
-        question_mark_count = len(re.findall(question_mark_regex, q))
-        if question_mark_count > 0:
-
-            q = re.sub(question_mark_regex, question_mark_replacement, q)
-
-            # Convert arguments to psycopg2's argument tuple
-            if not isinstance(q_args, tuple):  # might have been converted previously
-                q_args = tuple(q_args)
-
-            return q, q_args
-
-        else:
-            return None
-
-    def __replace_dollar_signs_or_return_none(q: str, q_args: list) -> Union[tuple, None]:
-        """Replace "$1" parameters with psycopg2's "%(param_1)s", or return None if not found."""
-
-        dollar_sign_regex = re.compile("""
-            (?P<char_before_dollar_sign>\s|,|\()    # Dollar sign preceded by whitespace, comma or bracket
-            \$(?P<param_index>\d)                   # Dollar sign with a single-digit index ("$1", "$2", ...)
-            (?=(\s|,|\)|(::)|$))                    # Lookahead and make sure dollar sign is singled out
-        """, flags=re.I | re.X)
-        dollar_sign_replacement = r'\g<char_before_dollar_sign>%(param_\g<param_index>)s'
-
-        dollar_sign_unique_indexes = set([x[1] for x in re.findall(dollar_sign_regex, q)])
-        dollar_sign_unique_count = len(dollar_sign_unique_indexes)
-        if dollar_sign_unique_count > 0:
-
-            q = re.sub(dollar_sign_regex, dollar_sign_replacement, q)
-
-            # Convert arguments to psycopg2's argument dictionary
-            if not isinstance(q_args, dict):  # might have been converted previously
-                q_args_dict = {}
-                for i in range(0, len(q_args)):
-                    q_args_dict['param_%d' % (i + 1)] = q_args[i]
-                q_args = q_args_dict
-
-            return q, q_args
-
-        else:
-            return None
-
-    # ---
 
     if len(query_parameters) == 0:
         raise McConvertDBDPgArgumentsToPsycopg2FormatException('No query or its parameters.')

--- a/mediacloud/mediawords/util/perl.py
+++ b/mediacloud/mediawords/util/perl.py
@@ -17,16 +17,9 @@ class McDecodeObjectFromBytesIfNeededException(Exception):
 # MC_REWRITE_TO_PYTHON: remove after porting all Perl code to Python
 def decode_object_from_bytes_if_needed(obj: Union[dict, list, tuple, str, bytes, None]) \
         -> Union[dict, list, tuple, str, None]:
-    """Convert object (dictionary, list or string) from 'bytes' string to 'unicode' if needed."""
+    """Convert object (dictionary, list or string) from 'bytes' string to 'unicode' if needed.
 
-    def __decode_string_from_bytes_if_needed(string: Union[int, str, bytes, None]) -> Union[int, str, None]:
-        """Convert 'bytes' string to 'unicode' if needed.
-        (http://search.cpan.org/dist/Inline-Python/Python.pod#PORTING_YOUR_INLINE_PYTHON_CODE_FROM_2_TO_3)"""
-        if string is not None:
-            if isinstance(string, bytes):
-                # mimic perl decode replace on error behavior
-                string = string.decode(encoding='utf-8', errors='replace')
-        return string
+    (http://search.cpan.org/dist/Inline-Python/Python.pod#PORTING_YOUR_INLINE_PYTHON_CODE_FROM_2_TO_3)"""
 
     if isinstance(obj, dict):
         result = dict()
@@ -46,7 +39,8 @@ def decode_object_from_bytes_if_needed(obj: Union[dict, list, tuple, str, bytes,
             result.append(v)
         result = tuple(result)
     elif isinstance(obj, bytes):
-        result = __decode_string_from_bytes_if_needed(obj)
+        # Mimic Perl decode replace on error behavior
+        result = obj.decode(encoding='utf-8', errors='replace')
     else:
         result = obj
     return result

--- a/mediacloud/mediawords/util/perl.py
+++ b/mediacloud/mediawords/util/perl.py
@@ -56,7 +56,7 @@ def decode_str_from_bytes_if_needed(obj: Union[bytes, str, None]) -> Union[str, 
     """Call decode_object_from_bytes_if_needed by only accept bytes and strings and only output strings."""
     decode = decode_object_from_bytes_if_needed(obj)
     if type(decode) not in (type('foo'), type(None)):
-        raise McDecodeObjectFromBytesIfNeededException("decoded object type '%s' is not str or None" % (type(obj,)))
+        raise McDecodeObjectFromBytesIfNeededException("decoded object type '%s' is not str or None" % (type(obj, )))
 
     return str(decode) if decode is not None else None
 

--- a/mediacloud/mediawords/util/url/__init__.py
+++ b/mediacloud/mediawords/util/url/__init__.py
@@ -41,14 +41,6 @@ def fix_common_url_mistakes(url: str) -> Optional[str]:
     """Fixes common URL mistakes (mistypes, etc.)."""
     url = decode_object_from_bytes_if_needed(url)
 
-    return fix_common_url_mistakes_no_decode(url)
-
-
-# noinspection SpellCheckingInspection
-def fix_common_url_mistakes_no_decode(url: str) -> Optional[str]:
-    """Fixes common URL mistakes (mistypes, etc.).
-
-    Don't decode_object_from_bytes.  Only safe to call from python."""
     if url is None:
         return None
 
@@ -342,20 +334,12 @@ def normalize_url_lossy(url: str) -> Optional[str]:
     """
     url = decode_object_from_bytes_if_needed(url)
 
-    return normalize_url_lossy_no_decode(url)
-
-
-# noinspection SpellCheckingInspection
-def normalize_url_lossy_no_decode(url: str) -> Optional[str]:
-    """Implement normalize_url_lossy as described above without calling decode_object_from_bytes_if_needed.
-
-    Only call directly from python."""
     if url is None:
         return None
     if len(url) == 0:
         return None
 
-    url = fix_common_url_mistakes_no_decode(url)
+    url = fix_common_url_mistakes(url)
 
     url = url.lower()
 


### PR DESCRIPTION
After reading through your https://github.com/berkmancenter/mediacloud/pull/423, I got weirded out by the performance problems of `decode_object_from_bytes_if_needed()`. In case of a native Python `str` parameter, it should have essentially been a no-op because the function merely runs `isinstance()` a couple of times against the passed parameter and after a while decides that there's nothing that needs to be done to a `str`, so the helper just returns it untouched.

100k calls to `decode_object_from_bytes_if_needed()` was taking 10 seconds, independently from whether `str` or `bytes` was being passed as a parameter (i.e. it didn't matter whether the function had to actually decode something).

It turns out that the catch was related to the "inner" function defined within the outer function and used as an internal helper:

```python
def foo(param):

    def bar(param_):
        return param_ + 1

    return bar(param)
```

Apparently Python reinterprets the inner `bar()` function *on every call* to `foo()` (probably because whether or not `bar()` gets defined at all might depend on the logic in `foo()`), thus making `foo()` way slower.

I got rid of this inner function in `decode_object_from_bytes_if_needed()`. Given that it's now literally 100x faster (even with `bytes` parameters when it has to do some actual decoding), I removed the `_no_decode` versions of various functions too. Lastly, I did the same to other parts of the code where such internal functions were being used (except for the tests where performance is not such a big concern).
