### PR TITLE
Encode CLIFF / NYTLabels annotations before returning them

### DIFF
--- a/lib/MediaWords/Controller/Admin/Stories.pm
+++ b/lib/MediaWords/Controller/Admin/Stories.pm
@@ -258,6 +258,9 @@ sub cliff_json : Local
           $stories_id . ": $@\nHashref: " . Dumper( $cliff_annotation );
     }
 
+    # Catalyst expects bytes
+    $annotation_json = encode_utf8( $annotation_json );
+
     $c->response->content_type( 'application/json; charset=UTF-8' );
     return $c->res->body( $annotation_json );
 }
@@ -303,6 +306,9 @@ sub nytlabels_json : Local
         die "Unable to encode story and its sentences annotation to JSON for story " .
           $stories_id . ": $@\nHashref: " . Dumper( $nytlabels_annotation );
     }
+
+    # Catalyst expects bytes
+    $annotation_json = encode_utf8( $annotation_json );
 
     $c->response->content_type( 'application/json; charset=UTF-8' );
     return $c->res->body( $annotation_json );

--- a/lib/MediaWords/Controller/Api/V2/Stories.pm
+++ b/lib/MediaWords/Controller/Api/V2/Stories.pm
@@ -142,6 +142,9 @@ sub cliff : Local
     Readonly my $json_pretty => 1;
     my $json = MediaWords::Util::JSON::encode_json( $json_items, $json_pretty );
 
+    # Catalyst expects bytes
+    $json = encode_utf8( $json );
+
     $c->response->content_type( 'application/json; charset=UTF-8' );
     $c->response->content_length( bytes::length( $json ) );
     $c->response->body( $json );
@@ -199,6 +202,9 @@ sub nytlabels : Local
 
     Readonly my $json_pretty => 1;
     my $json = MediaWords::Util::JSON::encode_json( $json_items, $json_pretty );
+
+    # Catalyst expects bytes
+    $json = encode_utf8( $json );
 
     $c->response->content_type( 'application/json; charset=UTF-8' );
     $c->response->content_length( bytes::length( $json ) );


### PR DESCRIPTION
Python's `encode_json()` implementation returns a string (as it should),
but Catalyst (the web framework) expects bytes, so UTF-8 characters such
as the em-dash cause a fatal error.

Fixes #429.