### PR TITLE
Remove backwards-compatible feed fields

### DIFF
--- a/lib/MediaWords/Controller/Api/V2/Feeds.pm
+++ b/lib/MediaWords/Controller/Api/V2/Feeds.pm
@@ -30,14 +30,14 @@ Readonly my $JOB_STATE_FIELD_LIST => "job_states_id, ( args->>'media_id' )::int 
 sub default_output_fields
 {
     return [
-        qw ( name url media_id feeds_id type feed_type active feed_status last_new_story_time
+        qw ( name url media_id feeds_id type feed_type active last_new_story_time
           last_attempted_download_time last_successful_download_time )
     ];
 }
 
 sub has_extra_data
 {
-    # Just to add deprecated "feed_type" and "feed_status"
+    # Just to add deprecated "feed_type"
     return 1;
 }
 
@@ -47,9 +47,6 @@ sub add_extra_data
 
     # Copy "type" to deprecated "feed_type"
     $feeds = [ map { $_->{ feed_type } = $_->{ type }; $_ } @{ $feeds } ];
-
-    # Copy "active" to deprecated "feed_status"
-    $feeds = [ map { $_->{ feed_status } = $_->{ active } ? 'active' : 'inactive'; $_ } @{ $feeds } ];
 
     return $feeds;
 }
@@ -66,7 +63,7 @@ sub list_query_filter_field
 
 sub get_update_fields($)
 {
-    return [ qw/name url type feed_type active feed_status/ ];
+    return [ qw/name url type feed_type active/ ];
 }
 
 sub update : Local : ActionClass('MC_REST')
@@ -90,20 +87,6 @@ sub update_PUT
     {
         $input->{ type } = $input->{ feed_type };
         delete $input->{ feed_type };
-    }
-
-    # Rename deprecated "feed_status" to "active"
-    if ( defined $input->{ feed_status } )
-    {
-        if ( $input->{ feed_status } eq 'active' )
-        {
-            $input->{ active } = 1;
-        }
-        else
-        {
-            $input->{ active } = 0;
-        }
-        delete $input->{ feed_status };
     }
 
     my $row = $c->dbis->update_by_id( 'feeds', $data->{ feeds_id }, $input );
@@ -131,20 +114,6 @@ sub create_GET
     {
         $input->{ type } = $input->{ feed_type };
         delete $input->{ feed_type };
-    }
-
-    # Rename deprecated "feed_status" to "active"
-    if ( defined $input->{ feed_status } )
-    {
-        if ( $input->{ feed_status } eq 'active' )
-        {
-            $input->{ active } = 1;
-        }
-        else
-        {
-            $input->{ active } = 0;
-        }
-        delete $input->{ feed_status };
     }
 
     my $row = $c->dbis->create( 'feeds', $input );

--- a/lib/MediaWords/Controller/Api/V2/StoriesBase.pm
+++ b/lib/MediaWords/Controller/Api/V2/StoriesBase.pm
@@ -302,10 +302,6 @@ SQL
                 f.media_id,
                 f.feeds_id,
                 f.type,
-
-                -- Copy "type" to deprecated "feed_type"
-                f.type AS feed_type,
-
                 fsm.stories_id
             FROM feeds AS f
                 JOIN feeds_stories_map AS fsm USING (feeds_id)

--- a/lib/MediaWords/Controller/Api/V2/StoriesBase.pm
+++ b/lib/MediaWords/Controller/Api/V2/StoriesBase.pm
@@ -306,12 +306,6 @@ SQL
                 -- Copy "type" to deprecated "feed_type"
                 f.type AS feed_type,
 
-                -- Copy "active" to deprecated "feed_status"
-                CASE
-                    WHEN f.active = 't' THEN 'active'
-                    ELSE 'inactive'
-                END AS feed_status,
-
                 fsm.stories_id
             FROM feeds AS f
                 JOIN feeds_stories_map AS fsm USING (feeds_id)

--- a/lib/MediaWords/Controller/Api/V2/t/Feeds.t
+++ b/lib/MediaWords/Controller/Api/V2/t/Feeds.t
@@ -35,13 +35,7 @@ sub test_feeds_list($)
             feeds.*,
 
             -- Copy "type" to deprecated "feed_type"
-            feeds.type AS feed_type,
-
-            -- Copy "active" to deprecated "feed_status"
-            CASE
-                WHEN feeds.active = 't' THEN 'active'
-                ELSE 'inactive'
-            END AS feed_status
+            feeds.type AS feed_type
             
         FROM feeds
         WHERE media_id = ?
@@ -51,7 +45,7 @@ SQL
 
     my $got_feeds = test_get( '/api/v2/feeds/list', { media_id => $medium->{ media_id } } );
 
-    my $fields = [ qw ( name url media_id feeds_id type feed_type active feed_status ) ];
+    my $fields = [ qw ( name url media_id feeds_id type feed_type active ) ];
     rows_match( $label, $got_feeds, $expected_feeds, "feeds_id", $fields );
 
     $label = "feeds/single";

--- a/lib/MediaWords/Controller/Api/V2/t/Feeds.t
+++ b/lib/MediaWords/Controller/Api/V2/t/Feeds.t
@@ -29,23 +29,11 @@ sub test_feeds_list($)
 
     map { MediaWords::Test::DB::create_test_feed( $db, "$label $_", $medium ) } ( 1 .. 10 );
 
-    my $expected_feeds = $db->query(
-        <<SQL,
-        SELECT
-            feeds.*,
-
-            -- Copy "type" to deprecated "feed_type"
-            feeds.type AS feed_type
-            
-        FROM feeds
-        WHERE media_id = ?
-SQL
-        $medium->{ media_id }
-    )->hashes;
+    my $expected_feeds = $db->query( "select * from feeds where media_id = ?", $medium->{ media_id } )->hashes;
 
     my $got_feeds = test_get( '/api/v2/feeds/list', { media_id => $medium->{ media_id } } );
 
-    my $fields = [ qw ( name url media_id feeds_id type feed_type active ) ];
+    my $fields = [ qw ( name url media_id feeds_id type active ) ];
     rows_match( $label, $got_feeds, $expected_feeds, "feeds_id", $fields );
 
     $label = "feeds/single";

--- a/lib/MediaWords/Controller/Api/V2/t/Stories.t
+++ b/lib/MediaWords/Controller/Api/V2/t/Stories.t
@@ -190,11 +190,7 @@ sub test_stories_public_list($$)
         <<SQL
         select
             feeds.*,
-            feeds.type AS feed_type,
-            CASE
-                WHEN feeds.active = 't' THEN 'active'
-                ELSE 'inactive'
-            END AS feed_status
+            feeds.type AS feed_type
         FROM feeds
         WHERE feeds_id IN (SELECT feeds_id FROM feeds_stories_map)
         LIMIT 1
@@ -213,7 +209,7 @@ SQL
         ok( $expected_story,
             "stories feed story $feed_story->{ stories_id } feed $feed->{ feeds_id } matches expected story" );
         is( scalar( @{ $feed_story->{ feeds } } ), 1, "stories feed one feed returned" );
-        for my $field ( qw/name url feeds_id media_id type feed_type feed_status/ )
+        for my $field ( qw/name url feeds_id media_id type feed_type/ )
         {
             is( $feed_story->{ feeds }->[ 0 ]->{ $field }, $feed->{ $field }, "feed story field $field" );
         }

--- a/lib/MediaWords/Controller/Api/V2/t/Stories.t
+++ b/lib/MediaWords/Controller/Api/V2/t/Stories.t
@@ -186,16 +186,8 @@ sub test_stories_public_list($$)
     # expect error when including q= and feeds_id=
     test_get( '/api/v2/stories_public/list', { q => 'foo', feeds_id => 1 }, 1 );
 
-    my $feed = $db->query(
-        <<SQL
-        select
-            feeds.*,
-            feeds.type AS feed_type
-        FROM feeds
-        WHERE feeds_id IN (SELECT feeds_id FROM feeds_stories_map)
-        LIMIT 1
-SQL
-    )->hash;
+    my $feed =
+      $db->query( "select * from feeds where feeds_id in ( select feeds_id from feeds_stories_map ) limit 1" )->hash;
     my $feed_stories =
       test_get( '/api/v2/stories_public/list', { rows => 100000, feeds_id => $feed->{ feeds_id }, show_feeds => 1 } );
     my $expected_feed_stories = $db->query( <<SQL, $feed->{ feeds_id } )->hashes;
@@ -209,7 +201,7 @@ SQL
         ok( $expected_story,
             "stories feed story $feed_story->{ stories_id } feed $feed->{ feeds_id } matches expected story" );
         is( scalar( @{ $feed_story->{ feeds } } ), 1, "stories feed one feed returned" );
-        for my $field ( qw/name url feeds_id media_id type feed_type/ )
+        for my $field ( qw/name url feeds_id media_id type/ )
         {
             is( $feed_story->{ feeds }->[ 0 ]->{ $field }, $feed->{ $field }, "feed story field $field" );
         }


### PR DESCRIPTION
As part of #416 (and https://github.com/berkmancenter/mediacloud/pull/421 deployment plan), we would be reverting backwards-compatible `feed_type` and `feed_status` fields in feed-related API responses.

Depends on:

* https://github.com/mitmedialab/MediaCloud-API-Client/pull/54 tested and deployed on frontend
* https://github.com/mitmedialab/MediaCloud-Web-Tools/pull/1165 tested and deployed on frontend

Fixes #416.