### PR TITLE
Make "mediawords_import_solr_data.pl" into a Supervisor service

### DIFF
--- a/mediawords.yml.dist
+++ b/mediawords.yml.dist
@@ -117,6 +117,7 @@ supervisor:
             #autorestart: true
 
         # other configurable supervisor programs
+        #import_solr_data
         #create_missing_partitions
         #copy_nonpartitioned_sentences_to_partitions
         #purge_object_caches

--- a/script/mediawords_import_solr_data.pl
+++ b/script/mediawords_import_solr_data.pl
@@ -1,15 +1,9 @@
 #!/usr/bin/env perl
+#
+# Generate and import dumps of PostgreSQL data for Solr
+#
 
 use forks;
-
-# generate and import dumps of postgres data for solr
-#
-# usage: mediawords_import_solr_data.pl [ --delta ] [ --delete_all ] [ --solr_url ] [ --file <file 1> ... ]
-#  --delta -- import stories that have changed since the last import
-#  --delete_all -- delete all existing data from solr, in an atomic transaction with the import
-#  --file -- import from a list of files rather than directly from postgres, files should be generated
-#            with mediawords_generate_solr_dump.pl
-#  --solr_url -- use the given solr_url to import rather than the solr_url in mediawords.yml
 
 use strict;
 use warnings;

--- a/supervisor/supervisord.conf.tt2
+++ b/supervisor/supervisord.conf.tt2
@@ -97,6 +97,18 @@ programs = crawler
     default_nice=5
 %]
 
+[%- import_solr_data_numprocs = supervisor.programs.import_solr_data.numprocs || 1 %]
+[% INCLUDE program_config
+    program='import_solr_data'
+    command="./script/run_in_env.sh ./script/mediawords_import_solr_data.pl --daemon --jobs $import_solr_data_numprocs"
+    default_stopasgroup='false'
+    default_killasgroup='false'
+    default_autorestart='false'
+    default_autostart='true'
+    skip_numprocs=1
+    default_nice=12
+%]
+
 [% INCLUDE program_config
     program='create_missing_partitions'
     command="./script/run_in_env.sh ./tools/db/create_missing_partitions.py"


### PR DESCRIPTION
Number of "jobs" (threads) is to be passed as `numprocs` (via `mediawords.yml`).

Fixes #425.