### PR TITLE
Disable concurrency in Celery

### DIFF
--- a/mediacloud/mediawords/job/__init__.py
+++ b/mediacloud/mediawords/job/__init__.py
@@ -198,4 +198,15 @@ class JobBrokerApp(Celery):
             'worker',
             '--loglevel', 'info',
             '--hostname', node_name,
+
+            # Use "solo" pool because:
+            #
+            # 1) We run (want want to run) a single job per process because multithreading is fun until it's not
+            # 2) Celery has concurrency bugs, e.g. sometimes gets "stuck" on a task
+            #
+            #        https://github.com/celery/celery/issues/3759#issuecomment-311763355
+            #
+            #    and a good way to avoid such concurrency bugs is just not to use concurrency.
+            #
+            '--pool', 'solo',
         ])

--- a/mediacloud/mediawords/job/__init__.py
+++ b/mediacloud/mediawords/job/__init__.py
@@ -163,8 +163,8 @@ class JobBrokerApp(Celery):
 
         self.conf.broker_connection_timeout = int(rabbitmq_config['timeout'])
 
-        worker_concurrency = config.get('celery', {}).get(job_class.__name__, {}).get('worker_concurrency', 1)
-        self.conf.worker_concurrency = worker_concurrency
+        # Concurrency is done by Supervisor, not Celery itself
+        self.conf.worker_concurrency = 1
 
         # Fetch only one job at a time
         self.conf.worker_prefetch_multiplier = 1


### PR DESCRIPTION
With some Celery jobs, when a task gets added to the queue, the worker receives the task and gets stuck immediately:

```
[2018-09-27 05:16:49,835: INFO/MainProcess] Received task: MediaWords::Job::Word2vec::GenerateSnapshotModel[c90c7055-25d9-4d1c-8a31-3b0c701e0239]  
# ...and then nothing happens
```

So, I've removed the multithreading support that you had in place because:

* Celery has a known concurrency bug, the workaround for which is just not to use concurrency: https://github.com/celery/celery/issues/3759#issuecomment-311763355
* Forks / threads are hard and error-prone, even Celery can't seem to get it right; our own code which isn't thread-safe (or otherwise aware and tested that it might be run as a thread / fork) could fail in various funky ways
* Doing stuff concurrently using separate processes (as started by Supervisor) works just fine, we should continue on using that and just that
* Celery's concurrency wasn't even configured on production so it wasn't active
* Undocumented `mediawords.yml` parameter
