### PR TITLE
Add snapshot job in the topic mine worker

### DIFF
--- a/lib/MediaWords/Job/TM/MineTopic.pm
+++ b/lib/MediaWords/Job/TM/MineTopic.pm
@@ -32,6 +32,7 @@ use MediaWords::CommonLibs;
 
 use MediaWords::TM::Mine;
 use MediaWords::DB;
+use MediaWords::Job::TM::SnapshotTopic;
 
 # only run one job for each topic at a time
 sub get_run_lock_arg
@@ -84,6 +85,9 @@ sub run_statefully($$;$)
     };
 
     MediaWords::TM::Mine::mine_topic( $db, $topic, $options );
+
+    INFO "Adding a new snapshot job for topics $topics_id...";
+    MediaWords::Job::TM::SnapshotTopic->add_to_queue( { topics_id => $topic->{ topics_id } } );
 }
 
 no Moose;    # gets rid of scaffolding

--- a/lib/MediaWords/TM/Mine.pm
+++ b/lib/MediaWords/TM/Mine.pm
@@ -2041,9 +2041,6 @@ sub do_mine_topic ($$;$)
         {
             update_topic_state( $db, $topic, "fetching social media data" );
             fetch_social_media_data( $db, $topic );
-
-            update_topic_state( $db, $topic, "snapshotting" );
-            MediaWords::TM::Snapshot::snapshot_topic( $db, $topic->{ topics_id } );
         }
     }
 }


### PR DESCRIPTION
Hey Hal,

Back when we were discussing job chain design in an old email thread (Hal was proposing maintaining such a chain in an XML file IIRC), we've agreed that we'll try to keep the inter-queue communication code in the worker code instead of adding new jobs wherever.

This would make every `MediaWords::Job::TM::MineTopic` job add a new job for snapshotting the topic and, subsequently, generating a word2vec model.

Easy fix, but I'm not sure how it might break your job status tracking code. Could you have a look?

Fixes #481.