### PR TITLE
Strip non-printable control characters before extracting

### DIFF
--- a/mediacloud/mediawords/util/test_extract_text.py
+++ b/mediacloud/mediawords/util/test_extract_text.py
@@ -133,3 +133,25 @@ def test_extract_article_from_html_long_space():
     extracted_text = extract_article_from_html(html)
 
     assert re.search(r'foo', extracted_text, flags=re.X)
+
+
+# Try out with different kinds of whitespace in a single sequence
+@timeout_decorator.timeout(seconds=5, use_signals=False)
+def test_extract_article_from_html_long_varied_whitespace():
+    long_space = ' \n\t\r' * 1000000
+    html = '<html><body><p>foo' + long_space + '</p></body></html>'
+
+    extracted_text = extract_article_from_html(html)
+
+    assert re.search(r'foo', extracted_text, flags=re.X)
+
+
+# Try out with different kinds of whitespace in a single sequence
+@timeout_decorator.timeout(seconds=5, use_signals=False)
+def test_extract_article_from_html_nonprintable_characters():
+    long_space = '\x00\x01\x02 ' * 1000000
+    html = '<html><body><p>foo' + long_space + '</p></body></html>'
+
+    extracted_text = extract_article_from_html(html)
+
+    assert re.search(r'foo', extracted_text, flags=re.X)

--- a/mediacloud/mediawords/util/test_text.py
+++ b/mediacloud/mediawords/util/test_text.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mediawords.util.text import McRandomStringException, random_string
+from mediawords.util.text import McRandomStringException, random_string, replace_control_nonprintable_characters
 
 
 def test_random_string():
@@ -18,3 +18,14 @@ def test_random_string():
     assert len(string_2) == length
     assert string_1.isalnum()
     assert string_2.isalnum()
+
+
+def test_replace_control_nonprintable_characters():
+    # "Ḃ" is 0x1E02, and if the function happened to input as bytes (i.e. without UTF-8 awareness),
+    # it might choose to strip 0x02 part, so we need to test for that
+    unicode_character = "Ḃ"
+    input_string = (b"\x00a\nb\r\nc\td\x7fe" + unicode_character.encode('utf-8') + b"f").decode('utf-8')
+    replacement = 'xyz'
+    expected_string = f"{replacement}a\nb\r\nc\td{replacement}e{unicode_character}f"
+    actual_string = replace_control_nonprintable_characters(string=input_string, replacement=replacement)
+    assert expected_string == actual_string

--- a/mediacloud/mediawords/util/text.py
+++ b/mediacloud/mediawords/util/text.py
@@ -1,5 +1,6 @@
 import random
-import string
+import re
+import string as py_string
 
 
 class McRandomStringException(Exception):
@@ -12,7 +13,18 @@ def random_string(length: int) -> str:
     if length < 1:
         raise McRandomStringException("Length must be >=1.")
 
-    chars = string.ascii_letters + string.digits
+    chars = py_string.ascii_letters + py_string.digits
     r = random.SystemRandom()
     rand_str = ''.join(r.choice(chars) for _ in range(length))
     return rand_str
+
+
+def replace_control_nonprintable_characters(string: str, replacement: str = ' ') -> str:
+    """Remove ASCII control characters except for \n, \r, and \t."""
+
+    # Allow 0x09 CHARACTER TABULATION
+    # Allow 0x0a LINE FEED (LF)
+    # Allow 0x0d CARRIAGE RETURN (CR)
+    string = re.sub(r'[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f-\x9f]', replacement, string)
+
+    return string


### PR DESCRIPTION
A certain download (downloads_id = 1620866179):

```
https://www.facebook.com/zuck?hc_ref=ARTIabbsED4833Xhh0R0ynoiQkRaK5MjwDzGp8AaJIyir_RMwcu9K2R-TqXg3tZzkGo&fref=nf&pnref=story
```

managed to return ~11 MB of data, most of which is weird sequences of
control characters:

```
0004f040: 673e 3c61 2068 7265 663d 2268 7474 7073  g><a href="https
0004f050: 3a2f 2f69 642d 6964 2e66 6163 6562 6f6f  ://id-id.faceboo
0004f060: 6b2e 636f 6d2f 7365 7074 6979 616e 692e  k.com/septiyani.
0004f070: 6265 6c6c 6122 3e4d 6172 6b20 5a75 636b  bella">Mark Zuck
0004f080: 6572 6265 7267 3c2f 613e 3c2f 7374 726f  erberg</a></stro
0004f090: 6e67 3e3c 2f64 6976 3e3c 6469 7620 636c  ng></div><div cl
0004f0a0: 6173 733d 2270 726f 6669 6c65 4672 6965  ass="profileFrie
0004f0b0: 6e64 7354 6578 7420 7072 6f66 696c 6546  ndsText profileF
0004f0c0: 7269 656e 6473 4279 6c69 6e65 2066 736d  riendsByline fsm
0004f0d0: 2066 776e 2066 6367 223e 28e3 8080 e380   fwn fcg">(.....
0004f0e0: 80e3 8080 20e3 8080 e380 80e3 8080 20e3  .... ......... .
0004f0f0: 8080 e380 80e3 8080 20e3 8080 e380 80e3  ........ .......
0004f100: 8080 20e3 8080 e380 80e3 8080 20e3 8080  .. ......... ...
0004f110: e380 80e3 8080 20e3 8080 e380 80e3 8080  ...... .........
0004f120: 20e3 8080 e380 80e3 8080 20e3 8080 e380   ......... .....
0004f130: 80e3 8080 20e3 8080 e380 80e3 8080 20e3  .... ......... .
0004f140: 8080 e380 80e3 8080 20e3 8080 e380 80e3  ........ .......
0004f150: 8080 20e3 8080 e380 80e3 8080 20e3 8080  .. ......... ...
```

(The 0xe3 0x80 0x80 goes on for the rest of the returned file.)

Is this a UTF-8 decoding error on our end? A buffer overflow somewhere?
Dunno.

Readability is not too happy with the control character sequence and got
stuck at it. So:

* Strip ASCII control characters (except for "\n", "\r" and "\t") before
extracting;
* Strip varied whitespace sequences (for example, not only "\t\t\t", but
also "\t\n \t\n " before extracting).