### PR TITLE
Cast API's integer parameters to int

### DIFF
--- a/lib/MediaWords/Controller/Api/V2/Feeds.pm
+++ b/lib/MediaWords/Controller/Api/V2/Feeds.pm
@@ -137,7 +137,7 @@ sub scrape_status_GET
 {
     my ( $self, $c ) = @_;
 
-    my $media_id = $c->req->params->{ media_id };
+    my $media_id = int( $c->req->params->{ media_id } // 0 );
 
     my $job_class = MediaWords::Job::RescrapeMedia->name;
 

--- a/lib/MediaWords/Controller/Api/V2/MC_REST_SimpleObject.pm
+++ b/lib/MediaWords/Controller/Api/V2/MC_REST_SimpleObject.pm
@@ -127,9 +127,7 @@ sub _process_result_list
 
     if ( $self->has_nested_data() )
     {
-
-        my $nested_data = $c->req->param( 'nested_data' );
-        $nested_data //= 1;
+        my $nested_data = int( $c->req->param( 'nested_data' ) // 1 );
 
         if ( $nested_data )
         {
@@ -159,8 +157,7 @@ sub single_GET
 
     my $query = "select * from $table_name where $id_field = ? ";
 
-    my $all_fields = $c->req->param( 'all_fields' );
-    $all_fields //= 0;
+    my $all_fields = int( $c->req->param( 'all_fields' ) // 0 );
 
     my $items = $c->dbis->query( $query, $id )->hashes();
 
@@ -571,7 +568,7 @@ END
         push( @{ $clear_tags_map->{ $id } }, $tags_id );
     }
 
-    if ( $c->req->params->{ clear_tags } )
+    if ( int( $c->req->params->{ clear_tags } // 0 ) )
     {
         $self->_clear_tags( $c, $clear_tags_map );
     }
@@ -642,7 +639,7 @@ sub process_put_tags($$)
 
     my $put_tags = [ map { $self->_process_single_put_tag( $c, $_ ) } @{ $data } ];
 
-    if ( $c->req->params->{ clear_tag_sets } )
+    if ( int( $c->req->params->{ clear_tag_sets } // 0 ) )
     {
         my $id_field       = $self->get_table_name . "_id";
         my $clear_tags_map = {};

--- a/lib/MediaWords/Controller/Api/V2/MC_REST_SimpleObject.pm
+++ b/lib/MediaWords/Controller/Api/V2/MC_REST_SimpleObject.pm
@@ -325,8 +325,7 @@ sub list_GET
     my $all_fields = $c->req->param( 'all_fields' );
     $all_fields //= 0;
 
-    my $rows = $c->req->param( 'rows' );
-    $rows //= $ROWS_PER_PAGE;
+    my $rows = int( $c->req->param( 'rows' ) || $ROWS_PER_PAGE + 0 );
     $rows = List::Util::min( $rows, 1_000 );
 
     # TRACE "rows $rows";

--- a/lib/MediaWords/Controller/Api/V2/Sentences.pm
+++ b/lib/MediaWords/Controller/Api/V2/Sentences.pm
@@ -141,8 +141,8 @@ sub list_GET
     my $q  = $c->req->params->{ 'q' };
     my $fq = $c->req->params->{ 'fq' };
 
-    my $start = $c->req->params->{ 'start' };
-    my $rows  = $c->req->params->{ 'rows' };
+    my $start = int( $c->req->params->{ 'start' } // 0 );
+    my $rows  = int( $c->req->params->{ 'rows' }  // 0 );
     my $sort  = $c->req->params->{ 'sort' };
 
     $rows  //= 1000;

--- a/lib/MediaWords/Controller/Api/V2/Sentences.pm
+++ b/lib/MediaWords/Controller/Api/V2/Sentences.pm
@@ -13,9 +13,13 @@ use Moose;
 use namespace::autoclean;
 use JSON::PP;
 use List::Compare;
+use Readonly;
 
 use MediaWords::Solr;
 use MediaWords::Util::ParseJSON;
+
+Readonly my $DEFAULT_ROW_COUNT => 1000;
+Readonly my $MAX_ROW_COUNT     => 10_000;
 
 =head1 NAME
 
@@ -142,11 +146,8 @@ sub list_GET
     my $fq = $c->req->params->{ 'fq' };
 
     my $start = int( $c->req->params->{ 'start' } // 0 );
-    my $rows  = int( $c->req->params->{ 'rows' }  // 0 );
+    my $rows  = int( $c->req->params->{ 'rows' }  // $DEFAULT_ROW_COUNT + 0 );
     my $sort  = $c->req->params->{ 'sort' };
-
-    $rows  //= 1000;
-    $start //= 0;
 
     $params->{ q }     = $q;
     $params->{ fq }    = $fq;
@@ -155,7 +156,7 @@ sub list_GET
 
     $params->{ sort } = _get_sort_param( $sort ) if ( $rows );
 
-    $rows = List::Util::min( $rows, 10000 );
+    $rows = List::Util::min( $rows, $MAX_ROW_COUNT + 0 );
 
     my $sentences = MediaWords::Solr::query_matching_sentences( $c->dbis, $params );
 

--- a/lib/MediaWords/Controller/Api/V2/Stories.pm
+++ b/lib/MediaWords/Controller/Api/V2/Stories.pm
@@ -106,7 +106,7 @@ sub cliff : Local
     my $json_list = {};
     for my $stories_id ( @{ $stories_ids } )
     {
-        $stories_id = $stories_id + 0;
+        $stories_id = int( $stories_id );
 
         next if ( $json_list->{ $stories_id } );
 
@@ -167,7 +167,7 @@ sub nytlabels : Local
     my $json_list = {};
     for my $stories_id ( @{ $stories_ids } )
     {
-        $stories_id = $stories_id + 0;
+        $stories_id = int( $stories_id );
 
         next if ( $json_list->{ $stories_id } );
 

--- a/lib/MediaWords/Controller/Api/V2/Tags.pm
+++ b/lib/MediaWords/Controller/Api/V2/Tags.pm
@@ -70,11 +70,8 @@ sub get_extra_where_clause
         push( @{ $clauses }, "and tag_sets_id in ( $tag_sets_ids_list )" );
     }
 
-    if ( my $similar_tags_id = $c->req->params->{ similar_tags_id } )
+    if ( my $similar_tags_id = int( $c->req->params->{ similar_tags_id } // 0 ) )
     {
-        # make sure this is an int
-        $similar_tags_id += 0;
-
         push( @{ $clauses }, <<SQL );
 and tags_id in (
     select b.tags_id
@@ -121,10 +118,9 @@ sub _fetch_list($$$$$$)
 {
     my ( $self, $c, $last_id, $table_name, $id_field, $rows ) = @_;
 
-    my $public = $c->req->params->{ public } || '';
+    my $public = int( $c->req->params->{ public } // 0 );
 
-    my $public_clause =
-      $public eq '1' ? 't.show_on_media or ts.show_on_media or t.show_on_stories or ts.show_on_stories' : '1=1';
+    my $public_clause = $public ? 't.show_on_media or ts.show_on_media or t.show_on_stories or ts.show_on_stories' : '1=1';
 
     $c->dbis->query( <<END );
 create temporary view tags as

--- a/lib/MediaWords/Controller/Api/V2/Topics/Foci.pm
+++ b/lib/MediaWords/Controller/Api/V2/Topics/Foci.pm
@@ -35,9 +35,9 @@ sub list_GET
 
     my $db = $c->dbis;
 
-    my $topics_id     = $c->stash->{ topics_id };
-    my $focal_sets_id = $c->req->params->{ focal_sets_id }
-      || die( 'missing required param foci_id' );
+    my $topics_id = $c->stash->{ topics_id };
+    my $focal_sets_id = int( $c->req->params->{ focal_sets_id } // 0 )
+      || die( 'missing required param focal_sets_id' );
 
     my $foci = $db->query( <<SQL, $focal_sets_id )->hashes;
 select foci_id, name, description, arguments->>'query' query

--- a/lib/MediaWords/Controller/Api/V2/Topics/Focus_Definitions.pm
+++ b/lib/MediaWords/Controller/Api/V2/Topics/Focus_Definitions.pm
@@ -50,7 +50,7 @@ sub list_GET
 
     my $topics_id = $c->stash->{ topics_id };
 
-    my $focal_set_definitions_id = $c->req->params->{ focal_set_definitions_id }
+    my $focal_set_definitions_id = int( $c->req->params->{ focal_set_definitions_id } // 0 )
       || die( "missing required param focal_set_definitions_id" );
 
     my $fds = $db->query( <<SQL, $focal_set_definitions_id )->hashes;

--- a/lib/MediaWords/Controller/Api/V2/Topics/Media.pm
+++ b/lib/MediaWords/Controller/Api/V2/Topics/Media.pm
@@ -143,10 +143,10 @@ sub list_GET
     my $timespans_id = $timespan->{ timespans_id };
     my $snapshots_id = $timespan->{ snapshots_id };
 
-    my $limit = $c->req->params->{ limit };
+    my $limit = int( $c->req->params->{ limit } // 0 );
     $limit = List::Util::min( $limit, 1_000 );
 
-    my $offset = $c->req->params->{ offset };
+    my $offset = int( $c->req->params->{ offset } // 0 );
 
     my $extra_clause = _get_extra_where_clause( $c, $timespans_id );
 
@@ -185,10 +185,10 @@ sub links_GET
 
     my $db = $c->dbis;
 
-    my $limit = $c->req->params->{ limit } || 1_000;
+    my $limit = int( $c->req->params->{ limit } // 1_000 );
     $limit = List::Util::min( $limit, 1_000_000 );
 
-    my $offset = $c->req->params->{ offset } || 0;
+    my $offset = int( $c->req->params->{ offset } // 0 );
 
     my $timespans_id = $timespan->{ timespans_id };
     my $snapshots_id = $timespan->{ snapshots_id };
@@ -218,12 +218,17 @@ sub map_GET
 
     my $timespan             = MediaWords::TM::set_timespans_id_param( $c );
     my $color_field          = $c->req->params->{ color_field } || 'media_type';
-    my $num_media            = $c->req->params->{ num_media } || 500;
-    my $include_weights      = $c->req->params->{ include_weights } || 0;
-    my $num_links_per_medium = $c->req->params->{ num_links_per_medium } || 1000;
+    my $num_media            = int( $c->req->params->{ num_media } // 500 );
+    my $include_weights      = int( $c->req->params->{ include_weights } // 0 );
+    my $num_links_per_medium = int( $c->req->params->{ num_links_per_medium } // 1000 );
     my $exclude_media_ids    = $c->req->params->{ exclude_media_ids } || [];
 
-    $exclude_media_ids = [ $exclude_media_ids ] unless ( ref( $exclude_media_ids ) eq ref( [] ) );
+    unless ( ref( $exclude_media_ids ) eq ref( [] ) )
+    {
+        $exclude_media_ids = [ $exclude_media_ids ];
+    }
+
+    $exclude_media_ids = [ map { int( $_ ) } @{ $exclude_media_ids } ];
 
     my $db = $c->dbis;
 

--- a/lib/MediaWords/Controller/Api/V2/Topics/Sentences.pm
+++ b/lib/MediaWords/Controller/Api/V2/Topics/Sentences.pm
@@ -43,8 +43,8 @@ sub count_GET
     my $timespan = MediaWords::TM::require_timespan_for_topic(
         $c->dbis,
         $c->stash->{ topics_id },
-        $c->req->params->{ timespans_id },
-        $c->req->params->{ snapshots_id }
+        int( $c->req->params->{ timespans_id } // 0 ),
+        int( $c->req->params->{ snapshots_id } // 0 )
     );
 
     my $q = $c->req->params->{ q };

--- a/lib/MediaWords/Controller/Api/V2/Topics/Timespans.pm
+++ b/lib/MediaWords/Controller/Api/V2/Topics/Timespans.pm
@@ -15,6 +15,13 @@ __PACKAGE__->config( action => { list => { Does => [ qw( ~TopicsReadAuthenticate
 sub apibase : Chained('/') : PathPart('api/v2/topics') : CaptureArgs(1)
 {
     my ( $self, $c, $topics_id ) = @_;
+
+    $topics_id = int( $topics_id // 0 );
+    unless ( $topics_id )
+    {
+        die "topics_id is unset.";
+    }
+
     $c->stash->{ topics_id } = $topics_id;
 }
 
@@ -34,11 +41,11 @@ sub list_GET
 
     my $db = $c->dbis;
 
-    my $topics_id = $c->stash->{ topics_id };
+    my $topics_id = int( $c->stash->{ topics_id } // 0 );
 
-    my $snapshots_id = $c->req->params->{ snapshots_id };
-    my $foci_id      = $c->req->params->{ foci_id };
-    my $timespans_id = $c->req->params->{ timespans_id };
+    my $snapshots_id = int( $c->req->params->{ snapshots_id } // 0 );
+    my $foci_id      = int( $c->req->params->{ foci_id }      // 0 );
+    my $timespans_id = int( $c->req->params->{ timespans_id } // 0 );
 
     my $snapshot = $db->require_by_id( 'snapshots', $snapshots_id ) if ( $snapshots_id );
     my $focus    = $db->require_by_id( 'foci',      $foci_id )      if ( $foci_id );

--- a/lib/MediaWords/Controller/Api/V2/Topics/Wc.pm
+++ b/lib/MediaWords/Controller/Api/V2/Topics/Wc.pm
@@ -20,6 +20,13 @@ __PACKAGE__->config( action => { list => { Does => [ qw( ~TopicsReadAuthenticate
 sub apibase : Chained('/') : PathPart('api/v2/topics') : CaptureArgs(1)
 {
     my ( $self, $c, $topics_id ) = @_;
+
+    $topics_id = int( $topics_id // 0 );
+    unless ( $topics_id )
+    {
+        die "topics_id is unset.";
+    }
+
     $c->stash->{ topics_id } = $topics_id;
 }
 
@@ -41,8 +48,8 @@ sub list_GET
     my $timespan = MediaWords::TM::require_timespan_for_topic(
         $c->dbis,
         $c->stash->{ topics_id },
-        $c->req->params->{ timespans_id },
-        $c->req->params->{ snapshots_id }
+        int( $c->req->params->{ timespans_id } // 0 ),
+        int( $c->req->params->{ snapshots_id } // 0 )
     );
 
     my $q = $c->req->params->{ q };

--- a/lib/MediaWords/Controller/Api/V2/Wc.pm
+++ b/lib/MediaWords/Controller/Api/V2/Wc.pm
@@ -39,10 +39,14 @@ sub list_GET : PathPrefix( '/api' )
 {
     my ( $self, $c ) = @_;
 
-    if ( $c->req->params->{ sample_size } && ( $c->req->params->{ sample_size } > 100_000 ) )
+    my $sample_size = int( $c->req->params->{ sample_size } // 0 );
+
+    if ( $sample_size and $sample_size > 100_000 )
     {
-        $c->req->params->{ sample_size } = 100_000;
+        $sample_size = 100_000;
     }
+
+    $c->req->params->{ sample_size } = $sample_size;
 
     my $wc = MediaWords::Solr::WordCounts->new( { db => $c->dbis, cgi_params => $c->req->params } );
 


### PR DESCRIPTION
Not every integer API parameter was being correctly sanitized (e.g. `int($rows)`), and in some cases the code wasn't using database handler's parameter interpolation (`$db->query('SELECT * FROM foo WHERE bar = ?', $bar)`) but instead was using Perl's variable interpolation (`$db->query("SELECT * FROM foo WHERE bar = $bar")`) without any kind of escaping being done, thus making the code susceptible to SQL injections, e.g.:

```
$ curl "https://api.mediacloud.org/api/v2/tags/list?rows=%27;%20bobby%20tables&key=<...>"

{"error":"Error(s): Caught exception in MediaWords::Controller::Api::V2::Tags->list \"Traceback (most recent call last):\n  File \"/home/mediacloud/mediacloud/mediacloud/mediawords/db/result/result.py\", line 77, in __execute\n    cursor.execute(*query_args)\n  File \"/home/mediacloud/.virtualenvs/mediacloud/lib/python3.7/site-packages/psycopg2/extras.py\", line 144, in execute\n    return super(DictCursor, self).execute(query, vars)\npsycopg2.DataError: invalid input syntax for integer: \"'\"\nLINE 7:     order by tags_id asc limit ''''\n                                       ^\n\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/home/mediacloud/mediacloud/mediacloud/mediawords/db/handler.py\", line 309, in query\n    print_warnings=self.__print_warnings)\n  File \"/home/mediacloud/mediacloud/mediacloud/mediawords/db/result/result.py\", line 35, in __init__\n    print_warnings=print_warnings)\n  File \"/home/mediacloud/mediacloud/mediacloud/mediawords/db/result/result.py\", line 114, in __execute\n    'mogrified_query': str(mogrified_query),\nmediawords.db.exceptions.result.McDatabaseResultException: Query failed: invalid input syntax for integer: \"'\"\nLINE 7:     order by tags_id asc limit ''''\n                                       ^\n; query: ('select *\\n    from tags\\n    where\\n        tags_id > %s \\n        \\n        \\n    order by tags_id asc limit %s\\n', (0, \"'\")); mogrified query: b\"select *\\n    from tags\\n    where\\n        tags_id > 0 \\n        \\n        \\n    order by tags_id asc limit ''''\\n\"\""}
```

This wasn't necessarily exploitable but the `'; bobby tables` parameter reaching database level is bad enough IMHO.

I've cast every integer parameter that I could find to `int`, with default values set where applicable. I haven't checked whether there exist instances where we run a SQL query with unsanitized strings (e.g. Solr queries) though; for reference, those are to be sanitized with `$db->quote()`.