### PR TITLE
Use FTS condition directly when searching for tags

### DIFF
--- a/lib/MediaWords/Controller/Api/V2/MC_REST_SimpleObject.pm
+++ b/lib/MediaWords/Controller/Api/V2/MC_REST_SimpleObject.pm
@@ -264,17 +264,19 @@ sub _fetch_list($$$$$$)
     my $name_clause         = $self->get_name_search_clause( $c );
     my $filter_field_clause = $self->_get_filter_field_clause( $c );
     my $extra_where_clause  = $self->get_extra_where_clause( $c );
-    my $order_by_clause     = $self->order_by_clause( $c ) || "$id_field asc";
+    my $order_by_clause     = $self->order_by_clause( $c ) || "$id_field ASC";
 
-    my $query = <<END;
-select *
-    from $table_name
-    where
-        $id_field > ? $name_clause
-        $extra_where_clause
-        $filter_field_clause
-    order by $order_by_clause limit ?
-END
+    my $query = <<"SQL";
+        SELECT *
+        FROM $table_name
+        WHERE
+            $id_field > ?
+            $name_clause
+            $extra_where_clause
+            $filter_field_clause
+        ORDER BY $order_by_clause
+        LIMIT ?
+SQL
 
     $list = $c->dbis->query( $query, $last_id, $rows )->hashes;
 

--- a/lib/MediaWords/Controller/Api/V2/Tags.pm
+++ b/lib/MediaWords/Controller/Api/V2/Tags.pm
@@ -38,7 +38,8 @@ sub get_name_search_clause
     my $db = $c->dbis;
 
     # create these as temp tables to force postgres planner to use tags fts index
-    $db->query( <<SQL, $v );
+    # (large "work_mem" allows executor to skip lengthy Bitmap Heap Scan in some cases)
+    $db->execute_with_large_work_mem( <<SQL, $v );
 create temporary table $temp_tags as
 select tags_id
     from tags t

--- a/lib/MediaWords/Controller/Api/V2/Tags.pm
+++ b/lib/MediaWords/Controller/Api/V2/Tags.pm
@@ -43,7 +43,7 @@ create temporary table $temp_tags as
 select tags_id
     from tags t
     where
-        to_tsvector('english', t.tag || ' ' || t.label) @@ plainto_tsquery(?)
+        to_tsvector('english', t.tag || ' ' || t.label) @@ plainto_tsquery('english', ?)
 SQL
 
     return <<END;

--- a/mediawords.yml.dist
+++ b/mediawords.yml.dist
@@ -344,9 +344,8 @@ mediawords:
     #uncomment to enable a 10 minute timeout
     #db_statement_timeout: "600000"
 
-    # Uncommit to speed up slow queries by setting the Postgresql work_mem parameter to this value
-    # By default the initial Postgresql value of work_mem is used
-    # large_work_mem: "3GB"
+    # "work_mem" value to use for queries run with execute_with_large_work_mem()
+    large_work_mem: "1GB"
 
     # An experiment parameter to dump stack traces in error message even if not in debug mode
     # NOTE: may leak DB passwords and is not to be use in production


### PR DESCRIPTION
Some more popular tag searches (`Trump`) end up finding hundreds of thousands of rows which then have to be rechecked by the FTS query, fetched and passed as a condition to the main `SELECT` in `_fetch_list()`. The caller `_fetch_list()`, in turn, has some conditions (`tags_id > ...` AND `LIMIT`) which might help the query planner limit the scope of the FTS search but those conditions don't get a chance to be used.

So, instead of creating a temporary table, simply pass the FTS condition SQL excerpt back to `_fetch_list()` and hope that PostgreSQL is smart enough to figure out which indexes are the most effective ones in the given circumstances.

Test query runs with FTS condition being used directly are pretty fast:

```
psql# EXPLAIN ANALYZE
SELECT *
FROM tags
WHERE tags_id > 0
  AND to_tsvector('english', tag || ' ' || label) @@ plainto_tsquery('english', 'India')
  AND tag_sets_id in ( 15765102 )
ORDER BY tags_id asc
LIMIT 20;

                                                                              QUERY PLAN                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1105.05..1105.10 rows=20 width=72) (actual time=127.015..127.025 rows=20 loops=1)
   ->  Sort  (cost=1105.05..1105.16 rows=46 width=72) (actual time=127.014..127.016 rows=20 loops=1)
         Sort Key: tags_id
         Sort Method: quicksort  Memory: 29kB
         ->  Bitmap Heap Scan on tags  (cost=1045.29..1103.83 rows=46 width=72) (actual time=119.317..126.952 rows=28 loops=1)
               Recheck Cond: ((tag_sets_id = 15765102) AND (to_tsvector('english'::regconfig, (((tag)::text || ' '::text) || (label)::text)) @@ '''india'''::tsquery))
               Filter: (tags_id > 0)
               Heap Blocks: exact=24
               ->  BitmapAnd  (cost=1045.29..1045.29 rows=46 width=0) (actual time=115.855..115.855 rows=0 loops=1)
                     ->  Bitmap Index Scan on tags_tag_sets_id  (cost=0.00..506.91 rows=45646 width=0) (actual time=3.198..3.198 rows=1542 loops=1)
                           Index Cond: (tag_sets_id = 15765102)
                     ->  Bitmap Index Scan on tags_fts  (cost=0.00..538.11 rows=60414 width=0) (actual time=112.591..112.591 rows=74450 loops=1)
                           Index Cond: (to_tsvector('english'::regconfig, (((tag)::text || ' '::text) || (label)::text)) @@ '''india'''::tsquery)
 Planning time: 1.151 ms
 Execution time: 127.108 ms
(15 rows)
```

Lastly, use `plainto_tsquery(config, query)` instead of `plainto_tsquery(query)` because [the former is `IMMUTABLE`](https://obartunov.livejournal.com/189806.html) and so query planner can come up with faster plans as it doesn't have to evaluate it over and over again for every row:

```
psql# SELECT routines.routine_name, COUNT(parameters.specific_name) AS argument_count, routines.is_deterministic
FROM information_schema.routines
    LEFT JOIN information_schema.parameters ON routines.specific_name=parameters.specific_name
WHERE routines.routine_name ~ 'to_tsquery'
GROUP BY routines.routine_name, routines.is_deterministic
ORDER BY routines.routine_name
;

   routine_name   | argument_count | is_deterministic 
------------------+----------------+------------------
 phraseto_tsquery |              1 | NO
 phraseto_tsquery |              2 | YES
 plainto_tsquery  |              1 | NO
 plainto_tsquery  |              2 | YES
 to_tsquery       |              1 | NO
 to_tsquery       |              2 | YES
(6 rows)
```

Fixes #495 (hopefully).
