### PR TITLE
Install patched Inline::Python which is more careful about printing stacktraces

### DIFF
--- a/ansible/roles/perl-dependencies/tasks/main.yml
+++ b/ansible/roles/perl-dependencies/tasks/main.yml
@@ -43,7 +43,7 @@
     - perl-dependencies
 
 - name: Install Inline::Python variant which die()s with tracebacks (stack traces)
-  command: "cpanm -v https://github.com/berkmancenter/mediacloud-inline-python-pm.git@v0.56-mediacloud"
+  command: "cpanm -v https://github.com/berkmancenter/mediacloud-inline-python-pm.git@v0.56.1-mediacloud"
   # No "args/creates" because installing from Git tree, so not sure how to
   # check which particular tag got installed
   environment: "{{ perlbrew_environment_variables_copy }}"


### PR DESCRIPTION
When Inline::Python encounters a Python-originating exception, it loads
"traceback" module and passes the exception to format_exception()
function to get a nicely formatted stacktrace.

Apparently, in some cases:

1) "traceback" can't be loaded (probably on some kinds of exceptions)
2) traceback.format_exception() fails as such

A patched Inline::Python is more careful about generating stacktraces:

https://github.com/berkmancenter/mediacloud-inline-python-pm/commit/ae0068405fa26f78f6c781e35dc82b2f060e2b4b

Fixes #529.