### PR TITLE
Serve /static/ files from data/webapp_static/, store RSS dumps there

### DIFF
--- a/ansible/roles/apache2-fcgi/handlers/main.yml
+++ b/ansible/roles/apache2-fcgi/handlers/main.yml
@@ -1,5 +1,5 @@
 - name: "Stop Apache service (MacOSX)"
-  command: brew services stop apache2
+  command: brew services stop httpd
   failed_when: false  # might not be started
   when: "ansible_distribution == 'MacOSX'"
   listen:
@@ -30,7 +30,7 @@
     - apache2-fcgi
 
 - name: "Start Apache service (MacOSX)"
-  command: brew services start apache2
+  command: brew services start httpd
   failed_when: false  # might not be started
   when: "ansible_distribution == 'MacOSX'"
   listen:

--- a/ansible/roles/apache2-fcgi/tasks/main-MacOSX.yml
+++ b/ansible/roles/apache2-fcgi/tasks/main-MacOSX.yml
@@ -1,11 +1,82 @@
 ---
 
 - name: Install Apache
-  homebrew:
-    name: "{{ item }}"
+  homebrew: 
+    name: httpd
     state: present
-  with_items:
-    - httpd24
-    - mod_fcgid
+  tags:
+    - apache2-fcgi
+
+- name: Test if mod_fcgid is installed
+  stat:
+    path: "{{ apache2_mod_fcgid_path }}"
+  register: have_mod_fcgid
+  become: true
+  become_user: "{{ mediacloud_user }}"
+  tags:
+    - apache2-fcgi
+
+- name: Install Perlbrew
+  block:
+
+    - name: Create temporary directory for mod_fcgid
+      tempfile:
+        state: directory
+        suffix: mod_fcgid_install
+      register: mod_fcgid_install_tempdir
+      become: true
+      become_user: "{{ mediacloud_user }}"
+      tags:
+        - apache2-fcgi
+
+    - name: Download mod_fcgid.tar.gz
+      get_url:
+        url: "{{ apache2_mod_fcgid_tarball_url }}"
+        dest: "{{ mod_fcgid_install_tempdir.path }}/mod_fcgid.tar.gz"
+      become: true
+      become_user: "{{ mediacloud_user }}"
+      tags:
+        - apache2-fcgi
+
+    - name: Extract mod_fcgid.tar.gz
+      unarchive:
+        remote_src: true
+        src: "{{ mod_fcgid_install_tempdir.path }}/mod_fcgid.tar.gz"
+        dest: "{{ mod_fcgid_install_tempdir.path }}"
+        extra_opts: ["--strip-components=1"]
+      become: true
+      become_user: "{{ mediacloud_user }}"
+      tags:
+        - apache2-fcgi
+
+    - name: Configure mod_fcgid
+      command: ./configure.apxs
+      args:
+        chdir: "{{ mod_fcgid_install_tempdir.path }}"
+      environment:
+        APXS: "{{ apache2_apxs_path }}"
+      become: true
+      become_user: "{{ mediacloud_user }}"
+      tags:
+        - apache2-fcgi
+
+    - name: Build mod_fcgid
+      make:
+        chdir: "{{ mod_fcgid_install_tempdir.path }}"
+      become: true
+      become_user: "{{ mediacloud_user }}"
+      tags:
+        - apache2-fcgi
+
+    - name: Install mod_fcgid
+      make:
+        chdir: "{{ mod_fcgid_install_tempdir.path }}"
+        target: install
+      become: "{{ apache2_conf_become }}"
+      become_user: root
+      tags:
+        - apache2-fcgi
+
+  when: have_mod_fcgid.stat.exists == False
   tags:
     - apache2-fcgi

--- a/ansible/roles/apache2-fcgi/templates/001-mediacloud.conf.j2
+++ b/ansible/roles/apache2-fcgi/templates/001-mediacloud.conf.j2
@@ -23,6 +23,12 @@
         AddHandler cgi-script   .cgi
     </Location>
 
+    # Static files served by the webapp
+    Alias           /static     {{ mediacloud_root }}/data/webapp_static
+    <Location /static>
+        SetHandler default-handler
+    </Location>
+
     FcgidMinProcessesPerClass  2
     FcgidIdleTimeout           3600
     FcgidProcessLifeTime       7200

--- a/ansible/roles/apache2-fcgi/vars/main-MacOSX.yml
+++ b/ansible/roles/apache2-fcgi/vars/main-MacOSX.yml
@@ -1,8 +1,12 @@
-apache2_conf_path: /usr/local/etc/apache2/2.4/
-apache2_conf_httpd_conf_path: /usr/local/etc/apache2/2.4/httpd.conf
-apache2_modules_path: libexec/
-apache2_mod_fcgid_path: /usr/local/opt/mod_fcgid/libexec/mod_fcgid.so
-apache2_log_path: /usr/local/var/log/apache2/
+apache2_conf_path: /usr/local/etc/httpd/
+apache2_conf_httpd_conf_path: /usr/local/etc/httpd/httpd.conf
+apache2_modules_path: lib/httpd/modules/
+apache2_mod_fcgid_path: /usr/local/opt/httpd/lib/httpd/modules/mod_fcgid.so
+apache2_log_path: /usr/local/var/log/httpd/
 apache2_http_port: 8080 # Homebrew Apache runs as unprivileged user
 apache2_https_port: 8081
 apache2_conf_become: false
+
+# Only used for macOS:
+apache2_mod_fcgid_tarball_url: http://apache.mirror.vu.lt/apache//httpd/mod_fcgid/mod_fcgid-2.3.9.tar.gz
+apache2_apxs_path: /usr/local/bin/apxs

--- a/ansible/roles/crontab/vars/main.yml
+++ b/ansible/roles/crontab/vars/main.yml
@@ -12,4 +12,4 @@ crontab_rotate_http_request_log_log_path: "{{ mediacloud_root }}/data/logs/rotat
 
 crontab_rescrape_due_media_log_path: "{{ mediacloud_root }}/data/logs/rescrape_media.log"
 
-crontab_rss_dump_path: "{{ mediacloud_root }}/data/rss_dumps"
+crontab_rss_dump_path: "{{ mediacloud_root }}/data/webapp_static/rss_dumps"

--- a/ansible/roles/perlbrew/tasks/main.yml
+++ b/ansible/roles/perlbrew/tasks/main.yml
@@ -41,6 +41,8 @@
         - perlbrew
 
   when: have_perlbrew.stat.executable is not defined or have_perlbrew.stat.executable == False
+  tags:
+    - perlbrew
 
 - name: Install Perlbrew cpanm
   command: "{{ perlbrew_root }}/bin/perlbrew install-cpanm"

--- a/data/webapp_static/.gitignore
+++ b/data/webapp_static/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything in this directory
+*
+# Except some files
+!.gitignore
+!README.md
+

--- a/data/webapp_static/README.md
+++ b/data/webapp_static/README.md
@@ -1,0 +1,2 @@
+This is where the static files for the Media Cloud web app should go to, accessible as /static/.
+

--- a/data/webapp_static/index.html
+++ b/data/webapp_static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://mediacloud.org/">
+    <title>Media Cloud</title>
+</head>
+<body>
+</body>
+</html>

--- a/data/webapp_static/rss_dumps/.gitignore
+++ b/data/webapp_static/rss_dumps/.gitignore
@@ -4,5 +4,4 @@
 !.gitignore
 !README.md
 !index.html
-!rss_dumps
 

--- a/data/webapp_static/rss_dumps/README.md
+++ b/data/webapp_static/rss_dumps/README.md
@@ -1,0 +1,2 @@
+RSS dumps for Archive.org.
+


### PR DESCRIPTION
* Create `data/webapp_static/` (exposed as `/static/` via Apache) to be used for serving static files.
* Store generated RSS dumps in `data/webapp_static/rss_dumps/` (available as https://api.mediacloud.org/static/rss_dumps/)
* Fix Apache 2 + mod_fcgid installation on macOS.