### PR TITLE
Set Access-Control-Allow-Origin for media.mit.edu / mediacloud.org origins

### DIFF
--- a/ansible/roles/apache2-fcgi/tasks/main.yml
+++ b/ansible/roles/apache2-fcgi/tasks/main.yml
@@ -191,6 +191,18 @@
   tags:
     - apache2-fcgi
 
+- name: Add LoadModule to headers.load  # OS X
+  lineinfile:
+    dest: "{{ apache2_conf_path }}/mods-available/headers.load"
+    regexp: "^LoadModule\\s+headers_module\\s+.+?$"
+    line: "LoadModule headers_module {{ apache2_modules_path }}/mod_headers.so"
+    create: true  # might not exist on OS X
+    state: present
+  become: "{{ apache2_conf_become }}"
+  become_user: root
+  tags:
+    - apache2-fcgi
+
 - name: Add LoadModule to mime.load  # OS X
   lineinfile:
     dest: "{{ apache2_conf_path }}/mods-available/mime.load"
@@ -237,6 +249,7 @@
     - alias
     - env
     - fcgid
+    - headers
     - mime
     - rewrite
   become: "{{ apache2_conf_become }}"

--- a/ansible/roles/apache2-fcgi/templates/001-mediacloud.conf.j2
+++ b/ansible/roles/apache2-fcgi/templates/001-mediacloud.conf.j2
@@ -21,6 +21,12 @@
         AddHandler fcgid-script .pl
         AddHandler fcgid-script .sh
         AddHandler cgi-script   .cgi
+
+        # Dynamic CORS header: https://stackoverflow.com/a/1850482/200603
+        SetEnvIf Origin "http(s)?://.*?(media\.mit\.edu|mediacloud\.org)$" AccessControlAllowOrigin=$0
+        Header add Access-Control-Allow-Origin %{AccessControlAllowOrigin}e env=AccessControlAllowOrigin
+        Header merge Vary Origin
+
     </Location>
 
     # Static files served by the webapp


### PR DESCRIPTION
Fixes #555.