### PR TITLE
Fix "raw_1st_download"

### DIFF
--- a/ansible/roles/postgresql-server/templates/01-mediacloud.conf.j2
+++ b/ansible/roles/postgresql-server/templates/01-mediacloud.conf.j2
@@ -45,8 +45,8 @@ deadlock_timeout = 10s
 
 synchronous_commit = off
 
-jit = on
-jit_above_cost = 50000000   # reset after finishing up "downloads" partitions
+# QP overestimates the cost for partitioned tables and decides to go for JIT needlessly
+jit = off
 
 max_worker_processes = 16
 max_parallel_workers_per_gather = 4

--- a/lib/MediaWords/Controller/Api/V2/StoriesBase.pm
+++ b/lib/MediaWords/Controller/Api/V2/StoriesBase.pm
@@ -63,7 +63,6 @@ sub _add_raw_1st_download
 {
     my ( $db, $stories ) = @_;
 
-    $db->begin;
     my $ids_table = $db->get_temporary_ids_table( [ map { int( $_->{ stories_id } ) } @{ $stories } ] );
 
     my $downloads = $db->query(
@@ -88,8 +87,6 @@ SQL
 
         $story->{ raw_first_download_file } = defined( $content ) ? $content : { missing => 'true' };
     }
-
-    $db->commit;
 }
 
 sub add_extra_data

--- a/lib/MediaWords/Controller/Api/V2/StoriesBase.pm
+++ b/lib/MediaWords/Controller/Api/V2/StoriesBase.pm
@@ -66,14 +66,13 @@ sub _add_raw_1st_download
     my $ids_table = $db->get_temporary_ids_table( [ map { int( $_->{ stories_id } ) } @{ $stories } ] );
 
     my $downloads = $db->query(
-        <<SQL
-        SELECT d.*
-        FROM downloads AS d
-        JOIN (
-            SELECT MIN(s.downloads_id) OVER (PARTITION BY s.stories_id ) AS downloads_id
-            FROM downloads AS s
-            WHERE s.stories_id IN (SELECT id FROM $ids_table)
-        ) AS q ON d.downloads_id = q.downloads_id
+        <<"SQL"
+        SELECT DISTINCT ON(stories_id) *
+        FROM downloads
+        WHERE stories_id IN (
+            SELECT id FROM $ids_table
+        )
+        ORDER BY stories_id, downloads_id
 SQL
     )->hashes;
 


### PR DESCRIPTION
* Use simpler, more straightforward query to fetch first download of every story.
* Disable PostgreSQL JIT query complication for now as the query planner overestimates the complexity on queries against partitioned tables so it often goes for JIT (which is way slower on fast and short queries). We could reenable JIT in the future but some extra experimentation would be needed before we do that.

Fixes #554.