### PR TITLE
add daily requests counts to users/list end point

### DIFF
--- a/doc/api_2_0_spec/admin_api_2_0_spec.md
+++ b/doc/api_2_0_spec/admin_api_2_0_spec.md
@@ -519,7 +519,7 @@ Output:
         "show_on_media": 0,
         "show_on_stories": 0,
         "is_static": 0
-    }    
+    }
 }
 ```
 
@@ -558,7 +558,7 @@ Output:
         "show_on_media": 0,
         "show_on_stories": 0,
         "is_static": 0
-    }    
+    }
 }
 ```
 
@@ -689,7 +689,7 @@ Output:
       "url": "http://nytimes.com/new/feed",
       "type": "syndicated",
       "active": true
-    }    
+    }
 }
 ```
 
@@ -701,7 +701,7 @@ Output:
 
 ### Input Description
 
-See api/v2/feeds/create above.  The input document can contain any subset of fields.  The document must also include a `feeds_id` field.  The `media_id` field cannot be changed.  
+See api/v2/feeds/create above.  The input document can contain any subset of fields.  The document must also include a `feeds_id` field.  The `media_id` field cannot be changed.
 
 ### Example
 
@@ -728,7 +728,7 @@ Output:
       "url": "http://nytimes.com/new/feed",
       "type": "syndicated",
       "active": false
-    }    
+    }
 }
 ```
 
@@ -740,7 +740,7 @@ Output:
 | ------------------- | ----------------------------------- |
 | api/v2/feeds/scrape | scrape a media source for new feeds |
 
-This end point scrapes through the web site of the given media source to try to discover new feeds.  
+This end point scrapes through the web site of the given media source to try to discover new feeds.
 
 This call queues a scraping job on the backend, which can take a few minutes or a few hours to complete. You can
 check the status of the scraping process for a given media source by calling `api/v2/feeds/scrape_status`.  The call
@@ -779,7 +779,7 @@ Output:
             "state": "queued"
         }
     ]
-}    
+}
 ```
 
 ## api/v2/feeds/scrape_status
@@ -838,7 +838,7 @@ Output:
             "state": "queued"
         }
     ]
-}    
+}
 ```
 
 
@@ -1078,7 +1078,7 @@ See `api/v2/users/list` below for sample output.
 URL: https://api.mediacloud.org/api/v2/users/list?search=foo
 
 Output:
- 
+
 ```
 [
   {
@@ -1094,7 +1094,24 @@ Output:
       "full_name": "Sample User",
       "max_topic_stories": 100000,
       "weekly_requests_limit": 10000,
-      "notes": "For demonstrating the user api
+      "notes": "For demonstrating the user api",i
+      "requests": [
+        {
+          "auth_users_id": 6308,
+          "day": "2017-08-31",
+          "requests_count": 91
+        },
+        {
+          "auth_users_id": 6308,
+          "day": "2017-09-01",
+          "requests_count": 9
+        },
+        {
+          "auth_users_id": 6308,
+          "day": "2017-09-02",
+          "requests_count": 19
+        }
+      ],
       "roles": [
         {
           "auth_users_id": 6308,
@@ -1104,7 +1121,7 @@ Output:
     },
   ]
 ]
- 
+
 ```
 
 ## api/v2/users/update (PUT)
@@ -1113,7 +1130,7 @@ Output:
 | ------------------- | ------------------------------- |
 | api/v2/users/update | update an existing user |
 
-This call updates a single existing user. 
+This call updates a single existing user.
 
 ### Input Description
 
@@ -1165,7 +1182,7 @@ Output:
 | ------------------- | ------------------------------- |
 | api/v2/users/delete | delete an existing user |
 
-This call deletes a single existing user. 
+This call deletes a single existing user.
 
 ### Input Description
 
@@ -1207,7 +1224,7 @@ none.
 URL: https://api.mediacloud.org/api/v2/users/list\_roles
 
 Output:
- 
+
 ```
 
 {
@@ -1249,6 +1266,6 @@ Output:
     }
   ]
 }
- 
+
 ```
 

--- a/lib/MediaWords/Controller/Api/V2/Users.pm
+++ b/lib/MediaWords/Controller/Api/V2/Users.pm
@@ -134,6 +134,13 @@ SQL
                 join auth_roles ar using ( auth_roles_id )  
 SQL
 
+    $users = $db->attach_child_query( $users, <<SQL, 'requests', 'auth_users_id' );
+        select au.auth_users_id, c.day, c.requests_count
+            from auth_user_request_daily_counts c
+                join auth_users au using ( email )
+            order by day
+SQL
+
     return $users;
 }
 


### PR DESCRIPTION
This PR adds a 'requests' field to the response for the users/list api end point.  We need this data to be able to generate the GDPR data dumps.  I just added the data to the existing end point because it is quite fast to query.