### PR TITLE
add efficient incremental respidering support to topics

### DIFF
--- a/lib/MediaWords/Controller/Api/V2/Topics.pm
+++ b/lib/MediaWords/Controller/Api/V2/Topics.pm
@@ -413,44 +413,31 @@ SQL
     return 0;
 }
 
-# if the query or dates have changed, set topic_stories.link_mined to false for the impacted stories so that
-# they will be respidered
+# if the query or dates have changed, set respider_stories in the topic to true so that the impacted
+# stories will be respidered during the next spider job.
 sub _set_stories_respidering($$$)
 {
     my ( $db, $topic, $data ) = @_;
 
     if ( $data->{ solr_seed_query } && ( $topic->{ solr_seed_query } ne $data->{ solr_seed_query } ) )
     {
-        $db->query( "update topic_stories set link_mined = 'f' where topics_id = ?", $topic->{ topics_id } );
+        $db->update_by_id( 'topics', $topic->{ topics_id }, { respider_stories => 't' } );
         return;
     }
 
     my $update_start_date = $data->{ start_date } || $topic->{ start_date };
     if ( $update_start_date ne $topic->{ start_date } )
     {
-        $db->query( <<SQL, $update_start_date, $topic->{ start_date }, $topic->{ topics_id } );
-update topic_stories ts set link_mined = 'f'
-    from stories s
-    where
-        ts.stories_id = s.stories_id and
-        s.publish_date between \$1 and ( \$2::date - '1 second'::interval ) and
-        ts.topics_id = \$3
-SQL
+        $db->update_by_id( 'topics', $topic->{ topics_id }, 
+            { respider_stories => 't', respider_start_date => $topic->{ start_date } } );
     }
 
     my $update_end_date = $data->{ end_date } || $topic->{ end_date };
     if ( $update_end_date ne $topic->{ end_date } )
     {
-        $db->query( <<SQL, $update_end_date, $topic->{ end_date }, $topic->{ topics_id } );
-update topic_stories ts set link_mined = 'f'
-    from stories s
-    where
-        ts.stories_id = s.stories_id and
-        s.publish_date between ( \$2::date + '1 second'::interval) and \$1 and
-        ts.topics_id = \$3
-SQL
+        $db->update_by_id( 'topics', $topic->{ topics_id }, 
+            { respider_stories => 't', respider_end_date => $topic->{ end_date } } );
     }
-
 }
 
 sub add_seed_query : Chained( 'apibase' ) : ActionClass( 'MC_REST' )

--- a/lib/MediaWords/Controller/Api/V2/t/Topics.t
+++ b/lib/MediaWords/Controller/Api/V2/t/Topics.t
@@ -320,17 +320,20 @@ SQL
     is( scalar( @{ $topic_stories } ), $num_stories );
 
     MediaWords::Controller::Api::V2::Topics::_set_stories_respidering( $db, $topic, { name => 'new respider name' } );
-    is( get_respider_count( $db, $topic ), 0, "respider count no scope update" );
+    $topic = $db->find_by_id( 'topics', $topic->{ topics_id } );
+    ok( !$topic->{ respider_stories }, "respider_stories not set after no scope pdate" );
 
     MediaWords::Controller::Api::V2::Topics::_set_stories_respidering( $db, $topic,
         { solr_seed_query => 'new respider name' } );
-    is( get_respider_count( $db, $topic ), $num_stories, "respider count query update" );
+    $topic = $db->find_by_id( 'topics', $topic->{ topics_id } );
+    ok( $topic->{ respider_stories }, "respider_stories set after query update" );
 
     $db->query( "update topic_stories set link_mined = 't' where topics_id = ?", $topic->{ topics_id } );
 
     my $start_date = '2017-01-01';
     my $end_date   = '2017-02-01';
-    $topic = $db->update_by_id( 'topics', $topic->{ topics_id }, { start_date => $start_date, end_date => $end_date } );
+    $topic = $db->update_by_id( 'topics', $topic->{ topics_id },
+        { respider_stories => 'f', start_date => $start_date, end_date => $end_date } );
 
     $db->query( <<SQL, $start_date, $medium->{ media_id } );
 update stories set publish_date = \$1 where media_id = \$2
@@ -346,9 +349,14 @@ update stories set publish_date = '2018-01-01'
     where stories_id in ( select stories_id from stories where media_id = ? order by stories_id desc limit 1 )
 SQL
 
+    my $respider_start_date = '2016-01-01';
+    my $respider_end_date = '2018-01-01';
     MediaWords::Controller::Api::V2::Topics::_set_stories_respidering( $db, $topic,
-        { start_date => '2016-01-01', end_date => '2018-01-01' } );
-    is( get_respider_count( $db, $topic ), 2, "respider count query update" );
+        { start_date => $respider_start_date, end_date => $respider_end_date } );
+    $topic = $db->find_by_id( 'topics', $topic->{ topics_id } );
+    ok( $topic->{ respider_stories }, "respider_stories set after date update" );
+    is( $topic->{ respider_start_date }, $respider_start_date, "respider_start_date set" );
+    is( $topic->{ respider_end_date }, $respider_end_date, "respider_end_date set" );
 }
 
 sub test_topics_reset

--- a/lib/MediaWords/TM/t/Mine.t
+++ b/lib/MediaWords/TM/t/Mine.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::Deep;
-use Test::More tests => 3;
+use Test::More tests => 7;
 
 use MediaWords::CommonLibs;
 
@@ -24,6 +24,7 @@ sub add_test_topic_stories($$$$)
     {
         my $story = MediaWords::Test::DB::Create::create_test_story( $db, "$label $i", $feed );
         MediaWords::TM::Stories::add_to_topic_stories( $db, $story, $topic );
+        $db->update_by_id( 'stories', $story->{ stories_id } , { publish_date => $topic->{ start_date } } );
     }
 }
 
@@ -55,16 +56,112 @@ sub test_die_if_max_stories_exceeded($)
     ok( $@, "$label adding 2001 stories to a 100 max_stories generates an error" );
 }
 
+sub test_respider($)
+{
+    my ( $db ) = @_;
+
+    my $label = "test_respider";
+
+    my $topic = MediaWords::Test::DB::Create::create_test_topic( $db, $label );
+
+    $topic->{ start_date } = '2017-01-01';
+    $topic->{ end_date } = '2018-01-01';
+
+    $topic = $db->update_by_id( 'topics', $topic->{ topics_id },
+        { max_stories => 0, start_date => '2017-01-01', end_date => '2018-01-01' } );
+
+    my $num_topic_stories = 101;
+    add_test_topic_stories( $db, $topic, $num_topic_stories, $label );
+
+    # no respidering without respider_stories
+    $db->query( "update topic_stories set link_mined = 't'" );
+
+    MediaWords::TM::Mine::set_stories_respidering( $db, $topic, undef );
+
+    my ( $got_num_respider_stories ) = $db->query( "select count(*) from topic_stories where not link_mined" )->flat;
+    is( $got_num_respider_stories, 0, "no stories marked for respidering" );
+
+    # respider everything with respider_stories but no dates
+    $topic->{ respider_stories } = 1;
+
+    $db->query( "update topic_stories set link_mined = 't'" );
+
+    MediaWords::TM::Mine::set_stories_respidering( $db, $topic, undef );
+
+    ( $got_num_respider_stories ) = $db->query( "select count(*) from topic_stories where not link_mined" )->flat;
+    is( $got_num_respider_stories, $num_topic_stories, "all stories marked for respidering" );
+
+    # respider stories within the range of changed dates
+    my $topic_update = {
+        respider_stories => 't',
+        respider_end_date => $topic->{ end_date },
+        respider_start_date => $topic->{ start_date },
+        end_date => '2019-01-01',
+        start_date => '2016-01-01',
+    };
+    $topic = $db->update_by_id( 'topics', $topic->{ topics_id }, $topic_update );
+
+    $db->query( "update topic_stories set link_mined = 't'" );
+
+    my $num_date_changes = 10;
+    $db->query( "update stories set publish_date = '2017-06-01'" );
+    $db->query( <<SQL, '2018-06-01', $num_date_changes );
+update stories set publish_date = ? where stories_id in 
+    (select stories_id from stories order by stories_id limit ?)
+SQL
+    $db->query( <<SQL, '2016-06-01', $num_date_changes );
+update stories set publish_date = ? where stories_id in 
+    (select stories_id from stories order by stories_id desc limit ?)
+SQL
+
+    my $snapshot = { 
+        topics_id => $topic->{ topics_id },
+        snapshot_date => MediaWords::Util::SQL::sql_now(),
+        start_date => $topic->{ start_date },
+        end_date => $topic->{ end_date }
+    };
+    $snapshot = $db->create( 'snapshots', $snapshot );
+
+    my $timespan_dates = 
+        [ [ '2017-01-01', '2017-01-31' ], [ '2017-12-20', '2018-01-20' ], [ '2016-12-20', '2017-01-20' ] ];
+    for my $dates ( @{ $timespan_dates } )
+    {
+        my ( $start_date, $end_date ) = @{ $dates };
+        my $timespan = {
+            snapshots_id => $snapshot->{ snapshots_id },
+            start_date => $start_date, 
+            end_date => $end_date,
+            period => 'monthly',
+            story_count => 0,
+            story_link_count => 0,
+            medium_count => 0,
+            medium_link_count => 0,
+            tweet_count => 0
+        };
+        $timespan = $db->create( 'timespans', $timespan );
+    }
+
+    MediaWords::TM::Mine::set_stories_respidering( $db, $topic, $snapshot->{ snapshots_id } );
+
+    ( $got_num_respider_stories ) = $db->query( "select count(*) from topic_stories where not link_mined" )->flat;
+    is( $got_num_respider_stories, 2 * $num_date_changes, "dated stories marked for respidering" );
+
+    my ( $got_num_archived_timespans ) = $db->query(
+        "select count(*) from timespans where archive_snapshots_id = ?", $snapshot->{ snapshots_id } )->flat;
+    is( $got_num_archived_timespans, 2, "number of archive timespans" );
+}
+
 sub test_mine($)
 {
     my ( $db ) = @_;
 
-    test_die_if_max_stories_exceeded( $db );
+    ( $db );
 }
 
 sub main
 {
-    MediaWords::Test::DB::test_on_test_database( \&test_mine );
+    MediaWords::Test::DB::test_on_test_database( \&test_die_if_max_stories_exceeded );
+    MediaWords::Test::DB::test_on_test_database( \&test_respider );
 }
 
 main();

--- a/mediacloud/mediawords/dbi/test_download_texts.py
+++ b/mediacloud/mediawords/dbi/test_download_texts.py
@@ -1,5 +1,5 @@
 from mediawords.dbi.download_texts import create
-from mediawords.test.db.create import create_test_medium, create_test_feed, create_download_for_feed
+from mediawords.test.db.create import create_test_medium, create_test_feed, create_test_story, create_download_for_story
 from mediawords.test.test_database import TestDatabaseWithSchemaTestCase
 
 
@@ -11,7 +11,8 @@ class TestDownloadTexts(TestDatabaseWithSchemaTestCase):
 
         self.test_medium = create_test_medium(self.db(), 'downloads test')
         self.test_feed = create_test_feed(self.db(), 'downloads test', self.test_medium)
-        self.test_download = create_download_for_feed(self.db(), self.test_feed)
+        self.test_story = create_test_story(self.db(), 'downloads test', self.test_feed)
+        self.test_download = create_download_for_story(self.db(), self.test_feed, self.test_story)
 
         self.test_download['path'] = 'postgresql:foo'
         self.test_download['state'] = 'success'


### PR DESCRIPTION
this pr adds two changes.  it changes the topics api to simply mark
a topic as needing story respidering when the query or date range
changes, then changes the topic spider to actually update the
topics_stories rows to mark them for respidering.  it also updates that
respidering logic to move the timespans of a snapshot that is being thus
respidered to archive any timespans within any date changes, so that
only impacted timespans will be regenerated but no timespan data will
actually be deleted.