### PR TITLE
Retry extracting three times

### DIFF
--- a/apps/common/docker-compose.tests.yml
+++ b/apps/common/docker-compose.tests.yml
@@ -18,10 +18,17 @@ services:
               source: ./tests/
               target: /opt/mediacloud/tests/
         depends_on:
+            - extract-article-from-page
             - postgresql-pgbouncer
             - solr-shard-01
             - import-solr-data-for-testing
             - rabbitmq-server
+
+    extract-article-from-page:
+        image: dockermediacloud/extract-article-from-page:latest
+        stop_signal: SIGKILL
+        expose:
+            - 8080
 
     import-solr-data-for-testing:
         image: dockermediacloud/import-solr-data-for-testing:latest

--- a/apps/common/src/python/mediawords/util/extract_article_from_page.py
+++ b/apps/common/src/python/mediawords/util/extract_article_from_page.py
@@ -46,9 +46,6 @@ def extract_article_html_from_page_html(content: str, config: Optional[CommonCon
     # Wait up to a minute for extraction to finish
     ua.set_timeout(EXTRACT_TIMEOUT)
 
-    # Retry extracting on failing HTTP status codes
-    ua.set_timing([1, 2, 4, 8])
-
     # Wait for the extractor's HTTP port to become open as the service might be still starting up somewhere
     api_uri = furl(api_url)
     api_url_hostname = str(api_uri.host)
@@ -95,7 +92,7 @@ def extract_article_html_from_page_html(content: str, config: Optional[CommonCon
 
     # Try extracting multiple times
     #
-    # UserAgent's set_timing() only retries on retryable HTTP status codes and doesn't retry on connection errors by
+    # UserAgent's set_timing() would only retry on retryable HTTP status codes and doesn't retry on connection errors by
     # default as such retries might have side effects, e.g. an API getting called multiple times. So, we retry
     # extracting the content a couple of times manually.
     http_response = None

--- a/apps/common/src/python/mediawords/util/extract_article_from_page.py
+++ b/apps/common/src/python/mediawords/util/extract_article_from_page.py
@@ -12,7 +12,6 @@ from mediawords.util.web.user_agent import Request, UserAgent
 
 log = create_logger(__name__)
 
-
 EXTRACTOR_SERVICE_TIMEOUT = 60
 """Seconds to wait for the extraction service to start."""
 
@@ -41,9 +40,9 @@ def extract_article_html_from_page_html(content: str) -> Dict[str, str]:
     assert api_url_port, f"API URL port is not set for URL {api_url}"
 
     if not wait_for_tcp_port_to_open(
-        port=api_url_port,
-        hostname=api_url_hostname,
-        retries=EXTRACTOR_SERVICE_TIMEOUT,
+            port=api_url_port,
+            hostname=api_url_hostname,
+            retries=EXTRACTOR_SERVICE_TIMEOUT,
     ):
         # Instead of throwing an exception, just crash the whole application
         # because there's no point in continuing on running it whatsoever:

--- a/apps/common/src/python/mediawords/util/extract_article_from_page.py
+++ b/apps/common/src/python/mediawords/util/extract_article_from_page.py
@@ -1,4 +1,3 @@
-import time
 from typing import Dict
 
 from furl import furl

--- a/apps/common/src/python/mediawords/util/extract_article_from_page.py
+++ b/apps/common/src/python/mediawords/util/extract_article_from_page.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from furl import furl
 
@@ -27,11 +27,21 @@ class McExtractArticleFromPageException(Exception):
     pass
 
 
-def extract_article_html_from_page_html(content: str) -> Dict[str, str]:
+def extract_article_html_from_page_html(content: str, config: Optional[CommonConfig] = None) -> Dict[str, str]:
+    """
+    Using full page HTML as a parameter, extract part of HTML that contains the news article.
+    :param content: Full page HTML.
+    :param config: Optional CommonConfig object, useful for testing.
+    :return: Dictionary with HTML that contains the news article content ("extracted_html" key) and extractor version
+             tag ("extractor_version" key).
+    """
     content = decode_object_from_bytes_if_needed(content)
 
+    if not config:
+        config = CommonConfig()
+
     ua = UserAgent()
-    api_url = CommonConfig.extractor_api_url()
+    api_url = config.extractor_api_url()
 
     # Wait up to a minute for extraction to finish
     ua.set_timeout(EXTRACT_TIMEOUT)

--- a/apps/common/tests/python/mediawords/util/test_extract_article_html_from_page_html.py
+++ b/apps/common/tests/python/mediawords/util/test_extract_article_html_from_page_html.py
@@ -1,7 +1,17 @@
+import multiprocessing
+from typing import Union
+from unittest import TestCase
+
+from mediawords.test.hash_server import HashServer
+from mediawords.util.config.common import CommonConfig
 from mediawords.util.extract_article_from_page import extract_article_html_from_page_html
+from mediawords.util.network import random_unused_port
+from mediawords.util.parse_json import encode_json
 
 
 def test_extract_article_html_from_page_html():
+    """Basic test."""
+
     content = """
     <html>
     <head>
@@ -24,3 +34,68 @@ def test_extract_article_html_from_page_html():
     assert 'readabilityBody' in response['extracted_html']  # <body id="readabilityBody">
 
     assert "readability-lxml" in response['extractor_version']
+
+
+class TestExtractConnectionErrors(TestCase):
+    """Extract the page but fail the first response."""
+
+    __slots__ = [
+        'is_first_response',
+    ]
+
+    expected_extracted_text = "Extraction worked the second time!"
+
+    def __extract_but_initially_fail(self, _: HashServer.Request) -> Union[str, bytes]:
+        """Page callback that fails initially but then changes its mind."""
+
+        with self.is_first_response.get_lock():
+            if self.is_first_response.value == 1:
+                self.is_first_response.value = 0
+
+                # Closest to a connection error that we can get
+                raise Exception("Whoops!")
+
+            else:
+                response = ""
+                response += "HTTP/1.0 200 OK\r\n"
+                response += "Content-Type: application/json; charset=UTF-8\r\n"
+                response += "\r\n"
+                response += encode_json({
+                    'extracted_html': self.expected_extracted_text,
+                    'extractor_version': 'readability-lxml',
+                })
+                return response
+
+    def test_extract_article_html_from_page_html_connection_errors(self):
+        """Try extracting with connection errors."""
+
+        # Use multiprocessing.Value() because request might be handled in a fork
+        self.is_first_response = multiprocessing.Value('i', 1)
+
+        pages = {
+            '/extract': {
+                'callback': self.__extract_but_initially_fail,
+            }
+        }
+        port = random_unused_port()
+
+        hs = HashServer(port=port, pages=pages)
+        hs.start()
+
+        class MockExtractorCommonConfig(CommonConfig):
+            """Mock configuration which points to our unstable extractor."""
+
+            def extractor_api_url(self) -> str:
+                return f'http://localhost:{port}/extract'
+
+        extractor_response = extract_article_html_from_page_html(content='whatever', config=MockExtractorCommonConfig())
+
+        hs.stop()
+
+        assert extractor_response
+        assert 'extracted_html' in extractor_response
+        assert 'extractor_version' in extractor_response
+
+        assert extractor_response['extracted_html'] == self.expected_extracted_text
+
+        assert not self.is_first_response.value, "Make sure the initial extractor call failed."

--- a/apps/common/tests/python/mediawords/util/test_extract_article_html_from_page_html.py
+++ b/apps/common/tests/python/mediawords/util/test_extract_article_html_from_page_html.py
@@ -1,0 +1,26 @@
+from mediawords.util.extract_article_from_page import extract_article_html_from_page_html
+
+
+def test_extract_article_html_from_page_html():
+    content = """
+    <html>
+    <head>
+    <title>I'm a test</title>
+    </head>
+    <body>
+    <p>Hi test, I'm dad!</p>
+    </body>
+    </html>        
+    """
+
+    response = extract_article_html_from_page_html(content=content)
+
+    assert response
+    assert 'extracted_html' in response
+    assert 'extractor_version' in response
+
+    assert "I'm a test" in response['extracted_html']
+    assert "Hi test, I'm dad!" in response['extracted_html']
+    assert 'readabilityBody' in response['extracted_html']  # <body id="readabilityBody">
+
+    assert "readability-lxml" in response['extractor_version']


### PR DESCRIPTION
`UserAgent`'s `set_timing()` retries requests only on retryable HTTP status codes but doesn't attempt to retry requests on, say, connection errors as such retries might have unintended side effects (e.g. some sort of API call getting called twice).

So, to cover for connection errors, retry extracting every extractor input three times on any error.
