### PR TITLE
Add pgAdmin 4 app for internal use

### DIFF
--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -1057,6 +1057,29 @@ services:
                     memory: "256M"
 
     #
+    # pgAdmin
+    # ---------
+    #
+    postgresql-pgadmin:
+        image: dockermediacloud/postgresql-pgadmin:release
+        <<: *sysctl-defaults
+        networks:
+            - default
+        depends_on:
+            - postgresql-server
+        ports:
+            # For connecting to through a SSH tunnel
+            - "5050:5050"
+        deploy:
+            <<: *misc-apps_deploy_placement_constraints
+            resources:
+                limits:
+                    # CPU core limit
+                    cpus: "4"
+                    # RAM limit
+                    memory: "1024M"
+
+    #
     # PgBouncer
     # ---------
     #

--- a/apps/postgresql-pgadmin/Dockerfile
+++ b/apps/postgresql-pgadmin/Dockerfile
@@ -1,0 +1,100 @@
+#
+# pgAdmin
+#
+
+FROM dockermediacloud/postgresql-base:latest
+
+RUN \
+    # FIXME
+    apt-get -y update && \
+    #
+    # Install PostgreSQL utilities to do backups etc.
+    apt-get -y --no-install-recommends install postgresql-client-11 && \
+    #
+    # Install dependencies
+    apt-get -y --no-install-recommends install python3 python3-pip python3-setuptools && \
+    #
+    # Upgrade Pip
+    pip3 install -U pip && \
+    # https://github.com/pypa/pip/issues/5221#issuecomment-382069604
+    hash -r pip3 && \
+    #
+    # Install temporary dependencies to be able to build pgAdmin
+    apt-get -y --no-install-recommends install build-essential python3-dev libffi-dev && \
+    #
+    # Install pgAdmin
+    pip3 install https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v4.14/pip/pgadmin4-4.14-py2.py3-none-any.whl && \
+    #
+    # Remove temporary dependencies
+    apt-get -y remove build-essential python3-dev libffi-dev && \
+    #
+    # Cleanup
+    apt-get -y autoremove && \
+    rm -rf /root/.cache/ && \
+    #
+    true
+
+# Install Gunicorn for serving web pages
+RUN pip3 install gunicorn==19.9.0
+
+# Some utilities assume that some version of Python is available as "python"
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Set up logging
+# (stuff gets logged to console so we just forward logs to /dev/null)
+RUN \
+    mkdir -p /var/log/pgadmin/ && \
+    rm -f /var/log/pgadmin/pgadmin4.log && \
+    ln -s /dev/null /var/log/pgadmin/pgadmin4.log && \
+    true
+
+# Copy .pgpass file
+RUN mkdir -p /var/lib/pgadmin/storage/mediacloud_mediacloud.org/
+COPY mediacloud.pgpass /var/lib/pgadmin/storage/mediacloud_mediacloud.org
+RUN chmod 0600 /var/lib/pgadmin/storage/mediacloud_mediacloud.org/mediacloud.pgpass
+# Set environment variable for "pg_dump" and similar utilities to use
+ENV PGPASSFILE /var/lib/pgadmin/storage/mediacloud_mediacloud.org/mediacloud.pgpass
+
+# Set up pgAdmin
+COPY mediacloud-servers.json /var/tmp/
+RUN \
+    #
+    # Configure path to PostgreSQL binaries
+    echo 'DEFAULT_BINARY_PATHS = {"pg": "/usr/bin", "ppas": "", "gpdb": ""}' \
+        >> /usr/local/lib/python3.5/dist-packages/pgadmin4/config_distro.py && \
+    #
+    # Make pgAdmin listen to all interfaces
+    echo 'DEFAULT_SERVER = "127.0.0.1"' \
+        >> /usr/local/lib/python3.5/dist-packages/pgadmin4/config_distro.py && \
+    #
+    # Configure mail server (although we won't be sending much mail)
+    echo 'MAIL_SERVER = "mail-postfix-server"' \
+        >> /usr/local/lib/python3.5/dist-packages/pgadmin4/config_distro.py && \
+    #
+    # Disable upgrade checks
+    echo 'UPGRADE_CHECK_ENABLED = False' \
+        >> /usr/local/lib/python3.5/dist-packages/pgadmin4/config_distro.py && \
+    #
+    # Initialize default configuration
+    export PGADMIN_SETUP_EMAIL="mediacloud@mediacloud.org" && \
+    export PGADMIN_SETUP_PASSWORD="mediacloud" && \
+    python3 /usr/local/lib/python3.5/dist-packages/pgadmin4/setup.py \
+        --load-servers /var/tmp/mediacloud-servers.json \
+        --user "$PGADMIN_SETUP_EMAIL" \
+        && \
+    unset PGADMIN_SETUP_EMAIL && \
+    unset PGADMIN_SETUP_PASSWORD && \
+    rm /var/tmp/mediacloud-servers.json && \
+    true
+
+# Copy wrapper script
+COPY pgadmin.sh /
+
+# pgAdmin data
+VOLUME /var/lib/pgadmin/
+
+# pgAdmin port
+EXPOSE 5050
+
+# Run pgAdmin
+CMD ["/pgadmin.sh"]

--- a/apps/postgresql-pgadmin/docker-compose.tests.yml
+++ b/apps/postgresql-pgadmin/docker-compose.tests.yml
@@ -1,0 +1,30 @@
+version: "3.7"
+
+services:
+
+    postgresql-pgadmin:
+        image: dockermediacloud/postgresql-pgadmin:latest
+        stop_signal: SIGKILL
+        ports:
+            # Expose to host for debugging
+            - "5050:5050"
+        volumes:
+            - type: bind
+              source: ./pgadmin.sh
+              target: /pgadmin.sh
+        depends_on:
+            - postgresql-pgbouncer
+
+    postgresql-pgbouncer:
+        image: dockermediacloud/postgresql-pgbouncer:latest
+        stop_signal: SIGKILL
+        expose:
+            - 6432
+        depends_on:
+            - postgresql-server
+
+    postgresql-server:
+        image: dockermediacloud/postgresql-server:latest
+        stop_signal: SIGKILL
+        expose:
+            - 5432

--- a/apps/postgresql-pgadmin/mediacloud-servers.json
+++ b/apps/postgresql-pgadmin/mediacloud-servers.json
@@ -1,0 +1,16 @@
+{
+    "Servers": {
+        "mediacloud": {
+            "Name": "postgresql-pgbouncer",
+            "Group": "Media Cloud",
+            "Host": "postgresql-pgbouncer",
+            "Port": 6432,
+            "Username": "mediacloud",
+            "PassFile": "mediacloud.pgpass",
+            "SSLMode": "disable",
+            "MaintenanceDB": "postgres",
+            "Comment": "Media Cloud PostgreSQL instance",
+            "Timeout": 60
+        }
+    }
+}

--- a/apps/postgresql-pgadmin/mediacloud.pgpass
+++ b/apps/postgresql-pgadmin/mediacloud.pgpass
@@ -1,0 +1,1 @@
+postgresql-pgbouncer:6432:*:mediacloud:mediacloud

--- a/apps/postgresql-pgadmin/pgadmin.sh
+++ b/apps/postgresql-pgadmin/pgadmin.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+exec gunicorn \
+    --bind 0.0.0.0:5050 \
+    --timeout 60 \
+    --workers 1 \
+    --threads 25 \
+    --chdir /usr/local/lib/python3.5/dist-packages/pgadmin4/ \
+    --access-logfile - \
+    pgAdmin4:app

--- a/doc/deploying.markdown
+++ b/doc/deploying.markdown
@@ -172,8 +172,15 @@ Both Media Cloud production's `docker-compose.yml` and Portainer's `docker-compo
 
 * Solr's webapp on port 8983
 * Munin's webapp on port 4948
-* RabbitMQ's webapp on port 15672
+* RabbitMQ's webapp on port 15672:
+    * username: `mediacloud`
+    * password: `mediacloud`
 * Portainer's webapp on port 9000
+    * username: `admin`
+    * password: `mediacloud`
+* pgAdmin on port 5050:
+    * username: `mediacloud@mediacloud.org`
+    * password: `mediacloud`
 
 To access those services, you might want to set up a SSH tunnel in your `~/.ssh/config` as follows:
 
@@ -194,6 +201,9 @@ Host mccore1
 
     # portainer
     LocalForward 9000 127.0.0.1:9000
+
+    # postgresql-pgadmin
+    LocalForward 5050 127.0.0.1:5050
 ```
 
 ### Deploying with Portainer
@@ -214,7 +224,7 @@ To deploy Portainer:
 
 3. Assuming that you have SSH port forwarding set up as per example below, you should be able to connect to Portainer's web UI by opening the following URL:
 
-   http://localhost:9000/
+   <http://localhost:9000/>
 
    and logging in with the following credentials:
 


### PR DESCRIPTION
Hey Hal!

I'm considering adding [pgAdmin 4](https://www.pgadmin.org/) as one of the internal "apps" that we could use via SSH tunnel.

Usual ways to connect to PostgreSQL in production aren't going anywhere, but this might make it easier to do some of the database work from a web browser (esp. the one on your Pixelbook).

<img width="1209" alt="Screenshot 2019-11-06 at 02 41 59" src="https://user-images.githubusercontent.com/181949/68236285-d97cdd00-003f-11ea-8137-83d409f66cb4.png">

What do you think? Next up I'll try to attach Python Notebooks (IPython) as one of the apps to make it easier for us to run random, one-off code on the production.
