### PR TITLE
Use wrapper script for `docker-compose` to make it quieter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "apps/cliff-annotator/src/CLIFF"]
 	path = apps/cliff-annotator/src/CLIFF
 	url = https://github.com/mitmedialab/CLIFF.git
+[submodule "dev/quieter-docker-compose"]
+	path = dev/quieter-docker-compose
+	url = https://github.com/berkmancenter/mediacloud-docker-compose-just-quieter.git

--- a/dev/run_all_tests.py
+++ b/dev/run_all_tests.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 from typing import List, Pattern
 
-from utils import DockerArgumentParser
+from utils import DockerComposeArgumentParser
 
 RUN_TEST_SCRIPT_FILENAME = 'run_test.py'
 """Script that will be called to run a single test."""
@@ -52,11 +52,12 @@ def _find_files_with_pattern(directory: str, filename_pattern: Pattern) -> List[
     return sorted(found_files)
 
 
-def docker_all_tests_commands(all_apps_dir: str) -> List[List[str]]:
+def docker_all_tests_commands(all_apps_dir: str, verbose: bool) -> List[List[str]]:
     """
     Return list commands to execute in order to run all test files from all apps.
 
     :param all_apps_dir: Directory with container subdirectories.
+    :param verbose: True if Docker Compose output should be more verbose.
     :return: List of commands (as lists) to execute in order to run all test files from all apps.
     """
 
@@ -98,20 +99,27 @@ def docker_all_tests_commands(all_apps_dir: str) -> List[List[str]]:
                 ))
 
             for test_file in perl_tests + python_tests:
-                commands.append([
+                command = [
                     run_test_script,
-                    '--all_apps_dir', all_apps_dir,
-                    test_file,
-                ])
+                    '--all_apps_dir',
+                    all_apps_dir,
+                ]
+
+                if verbose:
+                    command.append('--verbose')
+
+                command.append(test_file)
+
+                commands.append(command)
 
     return commands
 
 
 if __name__ == '__main__':
-    parser = DockerArgumentParser(description='Print commands to run all tests found in all apps.')
+    parser = DockerComposeArgumentParser(description='Print commands to run all tests found in all apps.')
     args = parser.parse_arguments()
 
-    commands_ = docker_all_tests_commands(all_apps_dir=args.all_apps_dir())
+    commands_ = docker_all_tests_commands(all_apps_dir=args.all_apps_dir(), verbose=args.verbose())
 
     if args.print_commands():
         for command_ in commands_:

--- a/dev/utils.py
+++ b/dev/utils.py
@@ -344,6 +344,43 @@ class DockerArgumentParser(object):
         return DockerArguments(self._parser.parse_args())
 
 
+class DockerComposeArguments(DockerArguments):
+    """
+    Arguments for scripts that use Docker Compose.
+    """
+
+    def verbose(self) -> bool:
+        """
+        Return True if docker-compose's output should be more verbose.
+
+        :return: True if docker-compose's output should be more verbose.
+        """
+        return self._args.verbose
+
+
+class DockerComposeArgumentParser(DockerArgumentParser):
+    """Argument parser for scripts that use Docker Compose."""
+
+    def __init__(self, description: str):
+        """
+        Constructor.
+
+        :param description: Description of the script to print when "--help" is passed.
+        """
+        super().__init__(description=description)
+
+        self._parser.add_argument('-v', '--verbose', action='store_true',
+                                  help='Print messages about starting and stopping containers.')
+
+    def parse_arguments(self) -> DockerComposeArguments:
+        """
+        Parse arguments and return an object with parsed arguments.
+
+        :return: DockerComposeArguments object.
+        """
+        return DockerComposeArguments(self._parser.parse_args())
+
+
 class DockerHubArguments(DockerArguments):
     """
     Arguments that include Docker Hub credentials.


### PR DESCRIPTION
Docker Compose is overly verbose when starting containers for a service:

```
$ docker-compose --project-name test run --rm test_service bash
Creating network "test-bash_default" with the default driver
Creating test-bash_postgresql-server_1         ... done
Creating test-bash_solr-zookeeper_1            ... done
Creating test-bash_extract-article-from-page_1 ... done
Creating test-bash_rabbitmq-server_1           ... done
Creating test-bash_solr-shard-01_1             ... done
Creating test-bash_import-solr-data-for-testing_1 ... done
```

Setting `--log-level` to `WARNING` doesn't seem to help, and multiple issues and PRs to address the issue have been unsuccessful so far:

* https://github.com/docker/compose/pull/6217
* https://github.com/docker/compose/pull/6194
* https://github.com/docker/compose/issues/6026

So, use a wrapper for `docker-compose` that monkey-patches Docker Compose for it to respect `--log-level`.

The wrapper is basically this script:

https://github.com/docker/compose/blob/master/bin/docker-compose

with some extra sauce to shut up the extra verbose logging; that makes it 100% compatible with vanilla `docker-compose` utility.

Scripts under `./dev/` will run in "quiet mode" by default unless an extra `-v` (`--verbose`) flag gets passed, e.g.:

```
$ ./dev/run.py postgresql-server pwd
/
$
```

Wrapper itself is available as a separate repo as it's potentially useful to others and could count as one of our open-source projects:

https://github.com/berkmancenter/mediacloud-docker-compose-just-quieter