### PR TITLE
Remove the noisiest temp. tables

### DIFF
--- a/apps/webapp-api/src/perl/MediaWords/Controller/Api/V2/Topics/Stories.pm
+++ b/apps/webapp-api/src/perl/MediaWords/Controller/Api/V2/Topics/Stories.pm
@@ -282,7 +282,9 @@ sub list_GET
     my $extra_clause = _get_extra_where_clause( $c, $timespans_id );
 
     my $offset = int( $c->req->params->{ offset } // 0 );
-    my $limit = int( $c->req->params->{ limit } );
+
+    $c->req->params->{ limit } = List::Util::min( int( $c->req->params->{ limit } // 1_000 ), 1_000_000 );
+    my $limit = $c->req->params->{ limit };
 
     my $pre_limit_order = $extra_clause ? '' : "$sort_clause limit $limit offset $offset";
 

--- a/apps/webapp-api/src/perl/MediaWords/Controller/Api/V2/Topics/Stories.pm
+++ b/apps/webapp-api/src/perl/MediaWords/Controller/Api/V2/Topics/Stories.pm
@@ -314,8 +314,6 @@ SQL
         $timespans_id, $snapshots_id
     )->hashes;
 
-    $db->query( "drop table _topics_stories_slc" );
-
     $stories = _add_foci_to_stories( $db, $timespan, $stories );
 
     MediaWords::DBI::Stories::GuessDate::add_date_is_reliable_to_stories( $db, $stories );

--- a/doc/api_2_0_spec/topics_api_2_0_spec.md
+++ b/doc/api_2_0_spec/topics_api_2_0_spec.md
@@ -1017,13 +1017,15 @@ The stories list call returns stories in the topic.
 | link_to_media_id     | null    | return only stories that link to stories in the given media |
 | link_from_media_id   | null    | return only stories that are linked from stories in the given media_id |
 | media_id             | null    | return only stories belonging to the given media_ids |
-| limit                | 20      | return the given number of stories       |
+| limit                | 1000    | return the given number of stories       |
 | link_id              | null    | return stories using the paging link     |
 
 The call will return an error if more than one of the following parameters are specified: `q`, `link_to_stories`, `link_from_stories_id`.  The `stories_id` and `media_id` parameters can be specified more than once to include stories from more than `stories_id` / `media_id`.
 
 The `sort` parameter will determine the order in which the stories are returned.  The `twitter` sort parameter
 will return randomly ordered results unless the topic is a twitter topic.
+
+`limit` is capped at 10,000,000 stories, but avoid getting that much to begin with.
 
 For a detailed description of the format of the query specified in `q` parameter, see the entry for [stories_public/list](api_2_0_spec.md) in the main API spec.
 


### PR DESCRIPTION
* Replaced one random one-off temp. table with a CTE in `::Controller::Api::V2::Topics::Stories`
* Replaced `_urls` temp. table with a CTE in `topics-fetch-link`, likely to be one of the biggest offenders of the `pg_attribute` bloat issue
