### PR TITLE
Postfix fixes

### DIFF
--- a/apps/base/Dockerfile
+++ b/apps/base/Dockerfile
@@ -66,6 +66,9 @@ RUN \
         netcat \
         # Some packages insist on logging to syslog
         rsyslog \
+        # "mail" utility (which uses msmtp internally)
+        s-nail \
+        # Timezone data, used by many packages
         tzdata \
         # Basic editor for files in container while debugging
         # (full vim doesn't cut it because it's too big and also installs

--- a/apps/base/Dockerfile
+++ b/apps/base/Dockerfile
@@ -51,6 +51,8 @@ RUN \
         ca-certificates \
         curl \
         htop \
+        # "ip" and similar utilities
+        iproute2 \
         # Pinging other containers from within Compose environment
         iputils-ping \
         # Sending mail via sendmail utility through mail-postfix-server

--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -1854,6 +1854,9 @@ networks:
             config:
                 # Docker (Compose?) sometimes defaults to a subnet with only
                 # 255 available addresses
+                #
+                # If you change this subnet, make sure that you update it
+                # elsewhere too, e.g. in "mail-opendkim-server"'s TrustedHosts
                 - subnet: "10.1.0.1/16"
 
 

--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -789,11 +789,7 @@ services:
             - default
         environment:
             # Top-level domain to use for signing emails, e.g. "mediacloud.org"
-            # (keep in sync with MC_MAIL_POSTFIX_DOMAIN)
             MC_MAIL_OPENDKIM_DOMAIN: "mediacloud.org"
-            # Mail server hostname, e.g. "mail" for "mail.mediacloud.org"
-            # (keep in sync with MC_MAIL_POSTFIX_HOSTNAME)
-            MC_MAIL_OPENDKIM_HOSTNAME: "mail"
         expose:
             # OpenDKIM port used by Postfix
             - "12301"

--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -822,12 +822,26 @@ services:
         networks:
             - default
         environment:
-            # Top-level domain to use for signing emails, e.g. "mediacloud.org"
-            # (keep in sync with MC_MAIL_OPENDKIM_DOMAIN)
-            MC_MAIL_POSTFIX_DOMAIN: "mediacloud.org"
-            # Mail server hostname, e.g. "mail" for "mail.mediacloud.org"
-            # (keep in sync with MC_MAIL_OPENDKIM_HOSTNAME)
-            MC_MAIL_POSTFIX_HOSTNAME: "mail"
+            # Fully qualified domain name of a host server that will be used for HELO messages.
+            #
+            # Must both resolve and have a PTR record, i.e. if an email sent by us arrives from
+            # 1.2.3.4, and that host has a hostname smtp.mediacloud.org, then both:
+            #
+            # 1) Sending IP address should have a PTR record that points to FQDN:
+            #
+            #     $ nslookup 1.2.3.4
+            #     <...>
+            #     4.3.2.1.in-addr.arpa  name = smtp.mediacloud.org
+            #
+            # 2) The FQDN should resolve to sending IP address:
+            #
+            #     $ nslookup smtp.mediacloud.org
+            #     <...>
+            #     Non-authoritative answer:
+            #     Name:   server.mediacloud.org
+            #     Address: 1.2.3.4
+            #
+            MC_MAIL_POSTFIX_FQDN: "smtp.mediacloud.org"
         depends_on:
             # Signs emails using OpenDKIM
             - mail-opendkim-server

--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -1857,6 +1857,7 @@ networks:
                 #
                 # If you change this subnet, make sure that you update it
                 # elsewhere too, e.g. in "mail-opendkim-server"'s TrustedHosts
+                # or "mail-postfix-server" Dockerfile
                 - subnet: "10.1.0.1/16"
 
 

--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -1858,7 +1858,7 @@ networks:
                 # If you change this subnet, make sure that you update it
                 # elsewhere too, e.g. in "mail-opendkim-server"'s TrustedHosts
                 # or "mail-postfix-server" Dockerfile
-                - subnet: "10.1.0.1/16"
+                - subnet: "10.1.0.0/16"
 
 
 #

--- a/apps/mail-opendkim-server/Dockerfile
+++ b/apps/mail-opendkim-server/Dockerfile
@@ -20,6 +20,9 @@ RUN rm -rf /etc/opendkim/ /etc/opendkim.conf
 COPY etc/opendkim.conf /etc/
 COPY etc/opendkim/ /etc/opendkim/
 
+# Copy TrustedHosts somewhere so that we could overwrite it in a volume with a wrapper script
+COPY etc/opendkim/TrustedHosts /var/lib/opendkim-TrustedHosts
+
 # OpenDKIM port
 EXPOSE 12301
 

--- a/apps/mail-opendkim-server/bin/opendkim.sh
+++ b/apps/mail-opendkim-server/bin/opendkim.sh
@@ -7,37 +7,32 @@ if [ -z "$MC_MAIL_OPENDKIM_DOMAIN" ]; then
     exit 1
 fi
 
-if [ -z "$MC_MAIL_OPENDKIM_HOSTNAME" ]; then
-    echo "MC_MAIL_OPENDKIM_HOSTNAME (mail server hostname) is not set."
-    exit 1
-fi
-
 set -u
 
 # (Re)generate dynamic configuration
 rm -f /etc/opendkim/KeyTable
-echo "${MC_MAIL_OPENDKIM_HOSTNAME}._domainkey.${MC_MAIL_OPENDKIM_DOMAIN} ${MC_MAIL_OPENDKIM_DOMAIN}:${MC_MAIL_OPENDKIM_HOSTNAME}:/etc/opendkim/keys/${MC_MAIL_OPENDKIM_HOSTNAME}.private" \
+echo "mail._domainkey.${MC_MAIL_OPENDKIM_DOMAIN} ${MC_MAIL_OPENDKIM_DOMAIN}:mail:/etc/opendkim/keys/mail.private" \
     > /etc/opendkim/KeyTable
 rm -f /etc/opendkim/SigningTable
-echo "*@${MC_MAIL_OPENDKIM_DOMAIN} ${MC_MAIL_OPENDKIM_HOSTNAME}._domainkey.${MC_MAIL_OPENDKIM_DOMAIN}" \
+echo "*@${MC_MAIL_OPENDKIM_DOMAIN} mail._domainkey.${MC_MAIL_OPENDKIM_DOMAIN}" \
     > /etc/opendkim/SigningTable
 rm -f /etc/opendkim/TrustedHosts
 cp /var/lib/opendkim-TrustedHosts /etc/opendkim/TrustedHosts
 
 # Generate keys if those are missing
-if [ ! -f "/etc/opendkim/keys/${MC_MAIL_OPENDKIM_HOSTNAME}.private" ]; then
+if [ ! -f "/etc/opendkim/keys/mail.private" ]; then
     opendkim-genkey \
-        -s "${MC_MAIL_OPENDKIM_HOSTNAME}" \
+        -s "mail" \
         -d "${MC_MAIL_OPENDKIM_DOMAIN}" \
         -D /etc/opendkim/keys/
-    chown opendkim:opendkim "/etc/opendkim/keys/${MC_MAIL_OPENDKIM_HOSTNAME}.private"
+    chown opendkim:opendkim "/etc/opendkim/keys/mail.private"
 fi
 
 # Print public key before every run
 echo
 echo "Add the following DNS record to ${MC_MAIL_OPENDKIM_DOMAIN} domain if you haven't already:"
 echo
-cat "/etc/opendkim/keys/${MC_MAIL_OPENDKIM_HOSTNAME}.txt"
+cat "/etc/opendkim/keys/mail.txt"
 echo
 
 # Set up rsyslog for logging

--- a/apps/mail-opendkim-server/bin/opendkim.sh
+++ b/apps/mail-opendkim-server/bin/opendkim.sh
@@ -21,6 +21,8 @@ echo "${MC_MAIL_OPENDKIM_HOSTNAME}._domainkey.${MC_MAIL_OPENDKIM_DOMAIN} ${MC_MA
 rm -f /etc/opendkim/SigningTable
 echo "*@${MC_MAIL_OPENDKIM_DOMAIN} ${MC_MAIL_OPENDKIM_HOSTNAME}._domainkey.${MC_MAIL_OPENDKIM_DOMAIN}" \
     > /etc/opendkim/SigningTable
+rm -f /etc/opendkim/TrustedHosts
+cp /var/lib/opendkim-TrustedHosts /etc/opendkim/TrustedHosts
 
 # Generate keys if those are missing
 if [ ! -f "/etc/opendkim/keys/${MC_MAIL_OPENDKIM_HOSTNAME}.private" ]; then

--- a/apps/mail-opendkim-server/etc/opendkim/TrustedHosts
+++ b/apps/mail-opendkim-server/etc/opendkim/TrustedHosts
@@ -1,3 +1,11 @@
+#
+# If you're editing this file in a volume in production, do note that the
+# changes will be overriden next time OpenDKIM starts.
+#
+# To make your changes permanent, edit the file in a repository, commit your
+# changes and rebuild "mail-opendkim-server" image.
+#
+
 127.0.0.1
 ::1
 localhost

--- a/apps/mail-opendkim-server/etc/opendkim/TrustedHosts
+++ b/apps/mail-opendkim-server/etc/opendkim/TrustedHosts
@@ -1,4 +1,6 @@
 127.0.0.1
+::1
+localhost
 mail-postfix-server
 10.1.*.*
 *.mediacloud_default

--- a/apps/mail-postfix-server/Dockerfile
+++ b/apps/mail-postfix-server/Dockerfile
@@ -35,6 +35,10 @@ RUN \
     postconf -e smtpd_milters=inet:mail-opendkim-server:12301 && \
     postconf -e non_smtpd_milters=inet:mail-opendkim-server:12301 && \
     #
+    # Reset hostname set by build server
+    postconf -e hostname=to-be-changed-later-at-runtime && \
+    postconf -e myhostname=to-be-changed-later-at-runtime && \
+    #
     # Relay all emails with a non-localhost destination
     postconf -e mydestination=localhost && \
     #

--- a/apps/mail-postfix-server/Dockerfile
+++ b/apps/mail-postfix-server/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     postconf -e queue_directory=/var/lib/postfix/queue/ && \
     #
     # Configure OpenDKIM
-    postconf -e milter_protocol=2 && \
+    postconf -e milter_protocol=6 && \
     postconf -e milter_default_action=accept && \
     postconf -e smtpd_milters=inet:mail-opendkim-server:12301 && \
     postconf -e non_smtpd_milters=inet:mail-opendkim-server:12301 && \

--- a/apps/mail-postfix-server/Dockerfile
+++ b/apps/mail-postfix-server/Dockerfile
@@ -59,14 +59,14 @@ RUN \
     #                                            (yes)   (yes)   (no)    (never) (100)
     # =================================================================================================
     postconf -M smtp/inet="      smtp      inet  n        -      n       -       -       smtpd"             && \
-    postconf -M pickup/unix="    pickup    unix  n       -       n       60      1       pickup"            && \
-    postconf -M cleanup/unix="   cleanup   unix  n       -       n       -       0       cleanup"            && \
+    postconf -M pickup/unix="    pickup    unix  n        -      n       60      1       pickup"            && \
+    postconf -M cleanup/unix="   cleanup   unix  n        -      n       -       0       cleanup"           && \
     postconf -M tlsmgr/unix="    tlsmgr    unix  -        -      n       1000?   1       tlsmgr"            && \
     postconf -M rewrite/unix="   rewrite   unix  -        -      n       -       -       trivial-rewrite"   && \
     postconf -M bounce/unix="    bounce    unix  -        -      n       -       0       bounce"            && \
     postconf -M defer/unix="     defer     unix  -        -      n       -       0       bounce"            && \
     postconf -M trace/unix="     trace     unix  -        -      n       -       0       bounce"            && \
-    postconf -M verify/unix="    verify    unix  -       -       n       -       1       verify"            && \
+    postconf -M verify/unix="    verify    unix  -        -      n       -       1       verify"            && \
     postconf -M flush/unix="     flush     unix  n        -      n       1000?   0       flush"             && \
     postconf -M smtp/unix="      smtp      unix  -        -      n       -       -       smtp"              && \
     postconf -M relay/unix="     relay     unix  -        -      n       -       -       smtp"              && \

--- a/apps/mail-postfix-server/Dockerfile
+++ b/apps/mail-postfix-server/Dockerfile
@@ -39,7 +39,7 @@ RUN \
     postconf -e inet_protocols=ipv4 && \
     #
     # Accept email from Docker network
-    postconf -e mynetworks=10.1.0.1/16 && \
+    postconf -e mynetworks=10.1.0.0/16 && \
     #
     # Don't require TLS as local clients are trusted
     postconf -e smtp_tls_security_level=may && \

--- a/apps/mail-postfix-server/Dockerfile
+++ b/apps/mail-postfix-server/Dockerfile
@@ -19,6 +19,9 @@ RUN \
     chown -R postfix:postfix /var/lib/postfix/ && \
     true
 
+# Copy header filter regexes
+COPY header_checks /etc/postfix/
+
 # Configure Postfix
 RUN \
     #
@@ -40,6 +43,11 @@ RUN \
     #
     # Accept email from Docker network
     postconf -e mynetworks=10.1.0.0/16 && \
+    #
+    # Filter out "Received:" and some other headers
+    postconf -e header_checks=regexp:/etc/postfix/header_checks && \
+    postconf -e mime_header_checks=regexp:/etc/postfix/header_checks && \
+    postconf -e smtp_header_checks=regexp:/etc/postfix/header_checks && \
     #
     # Don't require TLS as local clients are trusted
     postconf -e smtp_tls_security_level=may && \

--- a/apps/mail-postfix-server/Dockerfile
+++ b/apps/mail-postfix-server/Dockerfile
@@ -39,7 +39,7 @@ RUN \
     postconf -e inet_protocols=ipv4 && \
     #
     # Accept email from Docker network
-    postconf -e mynetworks=0.0.0.0/0 && \
+    postconf -e mynetworks=10.1.0.1/16 && \
     #
     # Don't require TLS as local clients are trusted
     postconf -e smtp_tls_security_level=may && \

--- a/apps/mail-postfix-server/bin/postfix.sh
+++ b/apps/mail-postfix-server/bin/postfix.sh
@@ -2,13 +2,8 @@
 
 set -e
 
-if [ -z "$MC_MAIL_POSTFIX_DOMAIN" ]; then
-    echo "MC_MAIL_POSTFIX_DOMAIN (top-level domain to use for sending email) is not set."
-    exit 1
-fi
-
-if [ -z "$MC_MAIL_POSTFIX_HOSTNAME" ]; then
-    echo "MC_MAIL_POSTFIX_HOSTNAME (mail server hostname) is not set."
+if [ -z "$MC_MAIL_POSTFIX_FQDN" ]; then
+    echo "MC_MAIL_POSTFIX_FQDN (fully qualified domain to use for sending email) is not set."
     exit 1
 fi
 
@@ -18,7 +13,8 @@ set -u
 source /rsyslog.inc.sh
 
 # Configure Postfix
-postconf -e hostname="${MC_MAIL_POSTFIX_HOSTNAME}.${MC_MAIL_POSTFIX_DOMAIN}"
+postconf -e hostname="${MC_MAIL_POSTFIX_FQDN}"
+postconf -e myhostname="${MC_MAIL_POSTFIX_FQDN}"
 
 # Set the right permissions in the data volume
 chown -R postfix:postfix /var/lib/postfix/

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -51,3 +51,8 @@ services:
 networks:
     default:
         attachable: true
+        ipam:
+            driver: default
+            config:
+                # Use same subnet as in production
+                - subnet: "10.1.0.1/16"

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -24,8 +24,7 @@ services:
         # To be able to set /proc/sys/kernel/yama/ptrace_scope:
         privileged: true
         environment:
-            MC_MAIL_POSTFIX_DOMAIN: "testmediacloud.ml"
-            MC_MAIL_POSTFIX_HOSTNAME: "mail"
+            MC_MAIL_POSTFIX_FQDN: "mail.testmediacloud.ml"
         depends_on:
             - mail-opendkim-server
         networks:

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -55,4 +55,4 @@ networks:
             driver: default
             config:
                 # Use same subnet as in production
-                - subnet: "10.1.0.1/16"
+                - subnet: "10.1.0.0/16"

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -36,7 +36,6 @@ services:
         image: dockermediacloud/mail-opendkim-server:latest
         environment:
             MC_MAIL_OPENDKIM_DOMAIN: "testmediacloud.ml"
-            MC_MAIL_OPENDKIM_HOSTNAME: "mail"
         expose:
             - "12301"
         volumes:

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -24,7 +24,7 @@ services:
         # To be able to set /proc/sys/kernel/yama/ptrace_scope:
         privileged: true
         environment:
-            MC_MAIL_POSTFIX_DOMAIN: "mediacloud.org"
+            MC_MAIL_POSTFIX_DOMAIN: "testmediacloud.ml"
             MC_MAIL_POSTFIX_HOSTNAME: "mail"
         depends_on:
             - mail-opendkim-server
@@ -36,7 +36,7 @@ services:
     mail-opendkim-server:
         image: dockermediacloud/mail-opendkim-server:latest
         environment:
-            MC_MAIL_OPENDKIM_DOMAIN: "mediacloud.org"
+            MC_MAIL_OPENDKIM_DOMAIN: "testmediacloud.ml"
             MC_MAIL_OPENDKIM_HOSTNAME: "mail"
         expose:
             - "12301"

--- a/apps/mail-postfix-server/header_checks
+++ b/apps/mail-postfix-server/header_checks
@@ -1,0 +1,5 @@
+/^Received:.*with ESMTP /         IGNORE
+/^X-Originating-IP:/    IGNORE
+/^X-Mailer:/            IGNORE
+/^Mime-Version:/        IGNORE
+/^User-Agent:/          IGNORE


### PR DESCRIPTION
* Fix up OpenDKIM to add DKIM signatures to outgoing mail.
* Make it possible to send email using `mail` utility (used by `munin-cron`) in addition to `sendmail` (both forward mail through Postfix server), so Munin alert emails should start working again.
* Set correct Postfix `myhostname` at runtime for it to be able to be resolved (so hopefully fixes #631).
* Filter out some headers in email messages in order to not leak out container names, IP addresses etc.
* Install `ip` utility in `base` so that one can find out containers' IP addresses and such.
