### PR TITLE
Remove "_u" temporary table in find_dup_story()

### DIFF
--- a/apps/common/src/python/mediawords/dbi/stories/stories.py
+++ b/apps/common/src/python/mediawords/dbi/stories/stories.py
@@ -87,7 +87,7 @@ def find_dup_story(db: DatabaseHandler, story: dict) -> Optional[dict]:
         SELECT *
         FROM stories
             JOIN matching_stories USING (stories_id)
-        WHERE stories_id.media_id = %(media_id)s
+        WHERE media_id = %(media_id)s
         ORDER BY stories_id
         LIMIT 1
 


### PR DESCRIPTION
* Super hard to find due to the name
* Spams the "pg_catalog" tables
* Could be easily redone into a CTE