### PR TITLE
Add dev script that prints `docker run` command to run one-off containers in production

### DIFF
--- a/dev/.idea/vcs.xml
+++ b/dev/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/quieter-docker-compose" vcs="Git" />
   </component>
 </project>

--- a/dev/build.py
+++ b/dev/build.py
@@ -52,26 +52,18 @@ class DockerImageToBuild(object):
         self.repository = repository
 
 
-def _docker_images_to_build(all_apps_dir: str, docker_hub_username: str) -> List[DockerImageToBuild]:
+def _docker_images_to_build(all_apps_dir: str) -> List[DockerImageToBuild]:
     """
     Return an ordered list of Docker images to build.
 
     :param all_apps_dir: Directory with app subdirectories.
-    :param docker_hub_username: Docker Hub username.
     :return: List of Docker images to build in that order.
     """
 
     images_to_build = []
 
-    for dependency in docker_images(
-            all_apps_dir=all_apps_dir,
-            only_belonging_to_user=True,
-            docker_hub_username=docker_hub_username,
-    ):
-        container_name = container_dir_name_from_image_name(
-            image_name=dependency,
-            docker_hub_username=docker_hub_username,
-        )
+    for dependency in docker_images(all_apps_dir=all_apps_dir, only_belonging_to_user=True):
+        container_name = container_dir_name_from_image_name(image_name=dependency)
         container_path = os.path.join(all_apps_dir, container_name)
 
         if not os.path.isdir(container_path):
@@ -92,11 +84,10 @@ if __name__ == '__main__':
 
     parser = DockerHubPruneArgumentParser(description='Print commands to build all container images.')
     args = parser.parse_arguments()
-    docker_hub_username_ = args.docker_hub_username()
 
     image_tag = docker_tag_from_current_git_branch_name()
 
-    images = _docker_images_to_build(all_apps_dir=args.all_apps_dir(), docker_hub_username=docker_hub_username_)
+    images = _docker_images_to_build(all_apps_dir=args.all_apps_dir())
 
     for image in images:
         command = "docker build --cache-from {repo}:latest --tag {repo}:{tag} --tag {repo}:latest {path}".format(

--- a/dev/print_docker_run_in_stack.py
+++ b/dev/print_docker_run_in_stack.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+"""
+Print 'docker run' command which joins a running stack with the right production configuration (environment variables).
+
+Usage:
+
+    ./dev/print_docker_run_in_stack.py ~/production-docker-config/docker-compose.yml topics-mine
+
+"""
+
+import argparse
+import shlex
+import sys
+from typing import List
+
+from utils import load_validate_docker_compose_yaml, InvalidDockerComposeYMLException
+
+
+def run_in_stack_command(
+        production_docker_compose_file: str,
+        service_name: str,
+        command: str,
+        stack_name: str,
+) -> List[str]:
+    """
+    Generate 'docker run' command which joins a running production stack and exports production's environment variables.
+
+    :param production_docker_compose_file: Path to production's docker-compose.yml
+    :param service_name: Service name to read the image name and environment variables from, e.g. "topics-mine".
+    :param command: Command to run in a newly started container.
+    :param stack_name: Name of a Docker stack to join.
+    :return: List of command parts in subprocess.check_call() syntax, i.e. ['docker', 'run', ...]
+    """
+    docker_compose_contents = load_validate_docker_compose_yaml(production_docker_compose_file)
+
+    networks = docker_compose_contents['networks']
+    if len(networks) != 1:
+        raise InvalidDockerComposeYMLException("I've expected to find a single network only.")
+
+    network_name = list(networks.keys())[0]
+    assert network_name
+
+    docker_run_command = [
+        'docker',
+        'run',
+        '-it',
+        '--network', '{}_{}'.format(stack_name, network_name),
+    ]
+
+    service = docker_compose_contents['services'].get(service_name, None)
+    if not service:
+        raise InvalidDockerComposeYMLException(
+            "Service '{}' was not found in '{}.".format(service_name, production_docker_compose_file)
+        )
+
+    service_env = service.get('environment', {})
+    if service_env:
+
+        if not isinstance(service_env, dict):
+            raise InvalidDockerComposeYMLException(
+                "Service's '{}' environment variables are not a dictionary".format(service_name)
+            )
+
+        for env_key, env_value in service_env.items():
+            docker_run_command.extend([
+                '-e',
+                '{}={}'.format(env_key, shlex.quote(env_value)),
+            ])
+
+    service_image = service.get('image', None)
+    if not service_image:
+        raise InvalidDockerComposeYMLException("Image is unset for service '{}'.".format(service_name))
+
+    docker_run_command.extend([
+        service_image,
+        command,
+    ])
+
+    return docker_run_command
+
+
+def _print_warning_message(message: str) -> None:
+    """
+    Print a colored warning message to STDERR.
+    :param message: Message to print.
+    """
+    color_start = '\033[93m'
+    color_end = '\033[0m'
+    print("{}{}{}".format(color_start, message, color_end), file=sys.stderr)
+    sys.stderr.flush()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Print 'docker run' command to run a new container in a Docker stack.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument('-n', '--stack_name', type=str, required=False, default='mediacloud',
+                        help='Docker stack name (from `docker stack deploy <...>`)')
+    parser.add_argument('-c', '--command', type=str, required=False, default='bash',
+                        help='Command to run in a newly started container')
+    parser.add_argument('production_docker_compose_file', type=str,
+                        help='Path to production docker-compose.yml')
+    parser.add_argument('service_name', type=str,
+                        help='Service to use for image name and environment variables')
+
+    args = parser.parse_args()
+
+    if not args.production_docker_compose_file.endswith('.yml'):
+        raise ValueError(
+            "Filename '{}' doesn't look like a YAML file to me.".format(args.production_docker_compose_file)
+        )
+
+    if '.dist.' in args.production_docker_compose_file:
+        raise ValueError(
+            "Filename '{}' doesn't look like a *production* docker-compose.yml to me.".format(
+                args.production_docker_compose_file
+            )
+        )
+
+    command_ = run_in_stack_command(
+        production_docker_compose_file=args.production_docker_compose_file,
+        service_name=args.service_name,
+        command=args.command,
+        stack_name=args.stack_name,
+    )
+
+    _print_warning_message("""
+Here's a "docker run" command that will:
+
+* Start a new container using "{service_name}" service's image and environment variables;
+* Make the container join "{stack_name}" Docker stack;
+* Run "{command}" in said container:
+    """.format(
+        service_name=args.service_name,
+        stack_name=args.stack_name,
+        command=args.command,
+    ))
+
+    # Add one extra space so that the command with secrets doesn't get stored in shell history
+    print(' ' + (' '.join(command_)))
+
+    _print_warning_message("""
+Make sure to:
+
+* Preserve a single whitespace in front of the command so that the command doesn't get logged in shell history;
+* Verify that you're starting a container using a correct image tag, e.g. "release".  
+""")

--- a/dev/pull.py
+++ b/dev/pull.py
@@ -16,39 +16,36 @@ This script can print the commands that are going to be run instead of running t
 import subprocess
 from typing import List
 
-from utils import docker_images, docker_tag_from_current_git_branch_name, DockerHubPruneArgumentParser
+from utils import docker_images, docker_tag_from_current_git_branch_name, DockerHubPruneArgumentParser, DOCKERHUB_USER
 
 
-def _docker_images_to_pull(all_apps_dir: str, docker_hub_username: str) -> List[str]:
+def _docker_images_to_pull(all_apps_dir: str) -> List[str]:
     """
     Return an ordered list of Docker images to pull.
 
     :param all_apps_dir: Directory with container subdirectories.
-    :param docker_hub_username: Docker Hub username.
     :return: List of tagged Docker images to pull in that order.
     """
     return docker_images(
         all_apps_dir=all_apps_dir,
         only_belonging_to_user=False,
-        docker_hub_username=docker_hub_username,
     )
 
 
-def _docker_pull_commands(all_apps_dir: str, image_tag: str, docker_hub_username: str, prune_images: bool) -> List[str]:
+def _docker_pull_commands(all_apps_dir: str, image_tag: str, prune_images: bool) -> List[str]:
     """
     Return an ordered list of "docker pull" commands to run in order to pull all images.
 
     :param all_apps_dir: Directory with container subdirectories.
     :param image_tag: Docker image tag.
-    :param docker_hub_username: Docker Hub username.
     :param prune_images: True if images are to be pruned after pulling each image to clean up disk space immediately.
     :return: List of "docker pull" commands to run in order to pull all images.
     """
     commands = []
 
-    for image in _docker_images_to_pull(all_apps_dir=all_apps_dir, docker_hub_username=docker_hub_username):
+    for image in _docker_images_to_pull(all_apps_dir=all_apps_dir):
 
-        if image.startswith(docker_hub_username_ + '/'):
+        if image.startswith(DOCKERHUB_USER + '/'):
 
             # 1) First try to pull the image for the current branch
             # 2) if that fails (e.g. the branch is new and it hasn't yet been built and tagged on Docker Hub), pull
@@ -83,12 +80,10 @@ def _docker_pull_commands(all_apps_dir: str, image_tag: str, docker_hub_username
 if __name__ == '__main__':
     parser = DockerHubPruneArgumentParser(description='Print commands to pull all container images.')
     args = parser.parse_arguments()
-    docker_hub_username_ = args.docker_hub_username()
 
     commands_ = _docker_pull_commands(
         all_apps_dir=args.all_apps_dir(),
         image_tag=docker_tag_from_current_git_branch_name(),
-        docker_hub_username=docker_hub_username_,
         prune_images=args.prune_images(),
     )
 

--- a/dev/push.py
+++ b/dev/push.py
@@ -17,33 +17,30 @@ This script can print the commands that are going to be run instead of running t
 import subprocess
 from typing import List
 
-from utils import docker_images, docker_tag_from_current_git_branch_name, DockerHubArgumentParser
+from utils import docker_images, docker_tag_from_current_git_branch_name, DockerArgumentParser
 
 
-def _docker_images_to_push(all_apps_dir: str, docker_hub_username: str) -> List[str]:
+def _docker_images_to_push(all_apps_dir: str) -> List[str]:
     """
     Return an ordered list of Docker images to push.
 
     :param all_apps_dir: Directory with container subdirectories.
-    :param docker_hub_username: Docker Hub username.
     :return: List of tagged Docker images to push in that order.
     """
     return docker_images(
         all_apps_dir=all_apps_dir,
         only_belonging_to_user=True,
-        docker_hub_username=docker_hub_username,
     )
 
 
 if __name__ == '__main__':
 
-    parser = DockerHubArgumentParser(description='Print commands to push all container images.')
+    parser = DockerArgumentParser(description='Print commands to push all container images.')
     args = parser.parse_arguments()
-    docker_hub_username_ = args.docker_hub_username()
 
     image_tag = docker_tag_from_current_git_branch_name()
 
-    for image in _docker_images_to_push(all_apps_dir=args.all_apps_dir(), docker_hub_username=docker_hub_username_):
+    for image in _docker_images_to_push(all_apps_dir=args.all_apps_dir()):
         command = ['docker', 'push', '{}:{}'.format(image, image_tag)]
 
         if args.print_commands():

--- a/dev/run_all_tests.py
+++ b/dev/run_all_tests.py
@@ -23,7 +23,6 @@ import os
 import re
 import shlex
 import subprocess
-import sys
 from typing import List, Pattern
 
 from utils import DockerComposeArgumentParser

--- a/dev/test_utils.py
+++ b/dev/test_utils.py
@@ -7,8 +7,7 @@ class TestUtils(TestCase):
 
     def test_container_dir_name_from_image_name(self):
         assert container_dir_name_from_image_name(
-            image_name='dockermediacloud/topics-fetch-twitter-urls:latest',
-            docker_hub_username='dockermediacloud',
+            image_name='dockermediacloud/topics-fetch-twitter-urls:latest'
         ) == 'topics-fetch-twitter-urls'
 
     def test_container_dependency_tree(self):

--- a/dev/utils.py
+++ b/dev/utils.py
@@ -9,8 +9,39 @@ import re
 import subprocess
 from typing import Dict, List, Set
 
+try:
+    from yaml import safe_load as load_yaml
+except ModuleNotFoundError:
+    raise ImportError("Please install PyYAML.")
 
 DOCKERHUB_USER = 'dockermediacloud'
+
+
+class InvalidDockerComposeYMLException(Exception):
+    """Exception that gets thrown on docker-compose.yml errors."""
+
+
+def load_validate_docker_compose_yaml(docker_compose_path: str) -> dict:
+    """
+    Load and validate docker-compose.yml, throw exception on errors.
+    :param docker_compose_path: Path to docker-compose.yml
+    :return Parsed docker-compose.yml.
+    """
+
+    if not os.path.isfile(docker_compose_path):
+        raise InvalidDockerComposeYMLException("YAML file does not exist: {}".format(docker_compose_path))
+
+    with open(docker_compose_path, mode='r', encoding='utf-8') as f:
+
+        try:
+            yaml_root = load_yaml(f)
+        except Exception as ex:
+            raise InvalidDockerComposeYMLException("Unable to load YAML file: {}".format(ex))
+
+        if 'services' not in yaml_root:
+            raise InvalidDockerComposeYMLException("No 'services' key under root.")
+
+    return yaml_root
 
 
 def _image_name_from_container_name(container_name: str) -> str:

--- a/dev/utils.py
+++ b/dev/utils.py
@@ -10,36 +10,37 @@ import subprocess
 from typing import Dict, List, Set
 
 
-def _image_name_from_container_name(container_name: str, docker_hub_username: str) -> str:
+DOCKERHUB_USER = 'dockermediacloud'
+
+
+def _image_name_from_container_name(container_name: str) -> str:
     """
     Convert container directory name to an image name.
 
     :param container_name: Container directory name.
-    :param docker_hub_username: Docker Hub username.
     :return: Image name (with username, prefix and version).
     """
     if not re.match(r'^[\w\-]+$', container_name):
         raise ValueError("Container name is invalid: {}".format(container_name))
 
     return '{username}/{container_name}'.format(
-        username=docker_hub_username,
+        username=DOCKERHUB_USER,
         container_name=container_name,
     )
 
 
-def container_dir_name_from_image_name(image_name: str, docker_hub_username: str) -> str:
+def container_dir_name_from_image_name(image_name: str) -> str:
     """
     Convert image name to a container directory name.
 
     :param image_name: Image name (with username, prefix and version).
-    :param docker_hub_username: Docker Hub username.
     :return: Container directory name.
     """
     container_name = image_name
 
-    expected_prefix = docker_hub_username + '/'
+    expected_prefix = DOCKERHUB_USER + '/'
     if not container_name.startswith(expected_prefix):
-        raise ValueError("Image name '{}' is expected to start with '{}/'.".format(image_name, docker_hub_username))
+        raise ValueError("Image name '{}' is expected to start with '{}/'.".format(image_name, DOCKERHUB_USER))
     container_name = container_name[len(expected_prefix):]
 
     # Remove version
@@ -48,12 +49,11 @@ def container_dir_name_from_image_name(image_name: str, docker_hub_username: str
     return container_name
 
 
-def _docker_parent_image_name(dockerfile_path: str, docker_hub_username: str) -> str:
+def _docker_parent_image_name(dockerfile_path: str) -> str:
     """
     Return Docker parent image name (FROM value) from a Dockerfile.
 
     :param dockerfile_path: Path to Dockerfile to parse.
-    :param docker_hub_username: Docker Hub username.
     :return: FROM value as found in the Dockerfile.
     """
     if not os.path.isfile(dockerfile_path):
@@ -71,7 +71,7 @@ def _docker_parent_image_name(dockerfile_path: str, docker_hub_username: str) ->
                 assert parent_image, "Parent image should be set at this point."
 
                 # Remove version tag if it's one of our own images
-                if parent_image.startswith(docker_hub_username + '/'):
+                if parent_image.startswith(DOCKERHUB_USER + '/'):
                     parent_image = re.sub(r':(.+?)$', '', parent_image)
 
                 return parent_image
@@ -79,23 +79,21 @@ def _docker_parent_image_name(dockerfile_path: str, docker_hub_username: str) ->
     raise ValueError("No FROM clause found in {}.".format(dockerfile_path))
 
 
-def _image_belongs_to_username(image_name: str, docker_hub_username: str) -> bool:
+def _image_belongs_to_username(image_name: str) -> bool:
     """
     Determine whether an image is hosted under a given Docker Hub username and thus has to be built.
 
     :param image_name: Image name (with username, prefix and version).
-    :param docker_hub_username: Docker Hub username.
     :return: True if image is to be hosted on a Docker Hub account pointed to in configuration.
     """
-    return image_name.startswith(docker_hub_username + '/')
+    return image_name.startswith(DOCKERHUB_USER + '/')
 
 
-def _container_dependency_map(all_apps_dir: str, docker_hub_username: str) -> Dict[str, str]:
+def _container_dependency_map(all_apps_dir: str) -> Dict[str, str]:
     """
     Determine which container depends on which parent image.
 
     :param all_apps_dir: Directory with container subdirectories.
-    :param docker_hub_username: Docker Hub username.
     :return: Map of dependent - dependency container directory names.
     """
     if not os.path.isdir(all_apps_dir):
@@ -108,13 +106,11 @@ def _container_dependency_map(all_apps_dir: str, docker_hub_username: str) -> Di
             container_name = os.path.basename(container_path)
             image_name = _image_name_from_container_name(
                 container_name=container_name,
-                docker_hub_username=docker_hub_username,
             )
 
             dockerfile_path = os.path.join(container_path, 'Dockerfile')
             parent_docker_image = _docker_parent_image_name(
                 dockerfile_path=dockerfile_path,
-                docker_hub_username=docker_hub_username,
             )
 
             parent_images[image_name] = parent_docker_image
@@ -162,31 +158,28 @@ def _ordered_container_dependencies(dependencies: Dict[str, str]) -> List[Set[st
     return tree
 
 
-def _ordered_dependencies_from_directory(all_apps_dir: str, docker_hub_username: str) -> List[Set[str]]:
+def _ordered_dependencies_from_directory(all_apps_dir: str) -> List[Set[str]]:
     """
     Return a list of sets of container names to build in order.
 
     :param all_apps_dir: Directory with container subdirectories.
-    :param docker_hub_username: Docker Hub username.
     :return: List of sets of container names in the order in which they should be built.
     """
-    dependency_map = _container_dependency_map(all_apps_dir=all_apps_dir, docker_hub_username=docker_hub_username)
+    dependency_map = _container_dependency_map(all_apps_dir=all_apps_dir)
     ordered_dependencies = _ordered_container_dependencies(dependency_map)
     return ordered_dependencies
 
 
-def docker_images(all_apps_dir: str, only_belonging_to_user: bool, docker_hub_username: str) -> List[str]:
+def docker_images(all_apps_dir: str, only_belonging_to_user: bool) -> List[str]:
     """
     Return a list of Docker images to pull / build / push in the correct order.
 
     :param all_apps_dir: Directory with container subdirectories.
     :param only_belonging_to_user: If True, return only the images that belong to the configured user.
-    :param docker_hub_username: Docker Hub username.
     :return: List of tagged Docker images to pull / build / push in the correct order.
     """
     ordered_dependencies = _ordered_dependencies_from_directory(
         all_apps_dir=all_apps_dir,
-        docker_hub_username=docker_hub_username,
     )
 
     images = []
@@ -195,7 +188,7 @@ def docker_images(all_apps_dir: str, only_belonging_to_user: bool, docker_hub_us
         for dependency in sorted(level_dependencies):
 
             if only_belonging_to_user:
-                if not _image_belongs_to_username(image_name=dependency, docker_hub_username=docker_hub_username):
+                if not _image_belongs_to_username(image_name=dependency):
                     continue
 
             images.append(dependency)
@@ -381,44 +374,7 @@ class DockerComposeArgumentParser(DockerArgumentParser):
         return DockerComposeArguments(self._parser.parse_args())
 
 
-class DockerHubArguments(DockerArguments):
-    """
-    Arguments that include Docker Hub credentials.
-    """
-
-    def docker_hub_username(self) -> str:
-        """
-        Return a Docker Hub username.
-
-        :return: Docker Hub username.
-        """
-        return self._args.dockerhub_user
-
-
-class DockerHubArgumentParser(DockerArgumentParser):
-    """Argument parser which requires Docker Hub credentials."""
-
-    def __init__(self, description: str):
-        """
-        Constructor.
-
-        :param description: Description of the script to print when "--help" is passed.
-        """
-        super().__init__(description=description)
-
-        self._parser.add_argument('-u', '--dockerhub_user', required=False, type=str, default='dockermediacloud',
-                                  help='Docker Hub user that is hosting the images.')
-
-    def parse_arguments(self) -> DockerHubArguments:
-        """
-        Parse arguments and return an object with parsed arguments.
-
-        :return: DockerHubArguments object.
-        """
-        return DockerHubArguments(self._parser.parse_args())
-
-
-class DockerHubPruneArguments(DockerHubArguments):
+class DockerHubPruneArguments(DockerArguments):
     """
     Arguments that include Docker Hub credentials and whether to prune images.
     """
@@ -432,7 +388,7 @@ class DockerHubPruneArguments(DockerHubArguments):
         return self._args.prune_images
 
 
-class DockerHubPruneArgumentParser(DockerHubArgumentParser):
+class DockerHubPruneArgumentParser(DockerArgumentParser):
     """Argument parser which requires Docker Hub credentials and allows users to prune images."""
 
     def __init__(self, description: str):

--- a/doc/tools.markdown
+++ b/doc/tools.markdown
@@ -6,6 +6,11 @@ Table of Contents
    * [tools app](#tools-app)
       * [Run tool in background](#run-tool-in-background)
       * [Attach tool to existing network](#attach-tool-to-existing-network)
+         * [In development](#in-development)
+         * [In production](#in-production)
+      * [Notes](#notes)
+         * [Tags](#tags)
+         * [Network names](#network-names)
       * [What is and isn't a "tool"](#what-is-and-isnt-a-tool)
 
 ----
@@ -41,7 +46,10 @@ Tue Jun 11 08:33:03 EDT 2019
 
 ## Attach tool to existing network
 
-If a tool is expected to access an existing Docker Compose environment (e.g. you want to run a tool against a production database), you can attach the tool container to said environment's network:
+
+### In development
+
+If a tool is expected to access an existing Docker Compose environment, you can attach the tool container to said environment's network:
 
 ```bash
 # (terminal 1) Create a sample network to attach to
@@ -59,7 +67,7 @@ cfeb15e2338f        mc-common-bash_default   bridge              local
 
 # (terminal 2) Using the "tools" image, start a new container with "bash" set as command and attach
 # it to the sample network that we've created in terminal 1
-$ docker run --network mediacloud_default -it dockermediacloud/tools:release bash
+$ docker run --network mc-common-bash_default -it dockermediacloud/tools:release bash
 
 # Container is now connected to the network and is able to access containers in it
 mediacloud@24352eba1be1:/$ ping -c 1 postgresql-pgbouncer
@@ -70,6 +78,13 @@ PING postgresql-pgbouncer (172.18.0.6) 56(84) bytes of data.
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
 rtt min/avg/max/mdev = 0.165/0.165/0.165/0.000 ms
 ```
+
+### In production
+
+If you'd like to run a one-off `tools` (or any other) container in production, you might want to not only join the right production network but also set the configuration environment variables in the container.
+
+For that purpose, consider using `print_docker_run_in_stack.py` script; please see [Developer scripts](dev_scripts.markdown).
+
 
 ## Notes
 


### PR DESCRIPTION
Hey Hal!

Following our discussion on improving a way to run random things (containers) on a production stack, I've came up with a new `print_docker_run_in_stack.py` development script which would read production's `docker-compose.yml`, come up with all the configuration environment variables for a particular service (e.g. `topics-mine`), and then print a `docker run` command which would start a new `topics-mine` container, make it join the production network and set the environment variables as well. An improvement over your `grep | awk` approach is that the script gets all the environment variables for a particular service right and escapes them properly.

Example: assuming that the production's `docker-compose.yml` is available at `~/production-docker-config/docker-compose.yml`, let's run on a local dev machine:

```shell
$ ./dev/print_docker_run_in_stack.py ~/production-docker-config/docker-compose.yml topics-mine
```

which would then print the following (mini-help included):

```
Here's a "docker run" command that will:

* Start a new container using "topics-mine" service's image and environment variables;
* Make the container join "mediacloud" Docker stack;
* Run "bash" in said container:
    
 docker run -it --network mediacloud_default -e MC_DOWNLOADS_STORAGE_LOCATIONS=amazon_s3 -e MC_DOWNLOADS_READ_ALL_FROM_S3=1 -e MC_DOWNLOADS_FALLBACK_POSTGRESQL_TO_S3=1 -e MC_DOWNLOADS_CACHE_S3=0 -e MC_DOWNLOADS_AMAZON_S3_ACCESS_KEY_ID=<...> -e MC_DOWNLOADS_AMAZON_S3_SECRET_ACCESS_KEY=<...> -e MC_DOWNLOADS_AMAZON_S3_BUCKET_NAME=<...> -e MC_DOWNLOADS_AMAZON_S3_DIRECTORY_NAME=<...> -e MC_EMAIL_FROM_ADDRESS=<...> -e MC_USERAGENT_BLACKLIST_URL_PATTERN=<...> -e MC_USERAGENT_AUTHENTICATED_DOMAINS=<...> -e MC_USERAGENT_PARALLEL_GET_NUM_PARALLEL=<...> -e MC_USERAGENT_PARALLEL_GET_TIMEOUT=30 -e MC_USERAGENT_PARALLEL_GET_PER_DOMAIN_TIMEOUT=1 -e MC_TOPICS_BASE_TOPIC_ALERT_EMAILS=<...> -e MC_TWITTER_CONSUMER_KEY=<...> -e MC_TWITTER_CONSUMER_SECRET=<...> -e MC_TWITTER_ACCESS_TOKEN=<...> -e MC_TWITTER_ACCESS_TOKEN_SECRET=<...> -e MC_CRIMSON_HEXAGON_API_KEY=<...> dockermediacloud/topics-mine:release bash

Make sure to:

* Preserve a single whitespace in front of the command so that the command doesn't get logged in shell history;
* Verify that you're starting a container using a correct image tag, e.g. "release".  
```

To start the actual container, one would have to SSH into one of the production servers and simply copy-paste the monstrosity of a `docker run` command from above.

What do you think? Does it make sense? What could be improved?
