### PR TITLE
Import UTF-8 stories into Solr correctly

### DIFF
--- a/apps/common/src/perl/MediaWords/Solr.pm
+++ b/apps/common/src/perl/MediaWords/Solr.pm
@@ -208,7 +208,7 @@ sub query_encoded_json($$;$)
 
     $params->{ fq } = [ map { _insert_collection_media_ids( $db, $_ ) } @{ $params->{ fq } } ];
 
-    my $response_content = MediaWords::Solr::Request::solr_request( 'select', {}, $params, 'application/x-www-form-urlencoded' );
+    my $response_content = MediaWords::Solr::Request::solr_request( 'select', {}, $params, 'application/x-www-form-urlencoded; charset=utf-8' );
 
     return $response_content;
 }

--- a/apps/common/src/perl/MediaWords/Solr/Request.pm
+++ b/apps/common/src/perl/MediaWords/Solr/Request.pm
@@ -185,7 +185,7 @@ sub solr_request($$;$$)
         $request = MediaWords::Util::Web::UserAgent::Request->new( 'POST', $abs_url );
         $request->set_header( 'Content-Type',   $content_type );
         $request->set_header( 'Content-Length', bytes::length( $content ) );
-        $request->set_content_utf8( $content );
+        $request->set_content( $content );
     }
     else
     {

--- a/apps/common/src/perl/MediaWords/Util/Web/UserAgent/Request.pm
+++ b/apps/common/src/perl/MediaWords/Util/Web/UserAgent/Request.pm
@@ -136,13 +136,6 @@ sub set_content($$)
 {
     my ( $self, $content ) = @_;
 
-    $self->{ _request }->set_content( $content );
-}
-
-sub set_content_utf8($$)
-{
-    my ( $self, $content ) = @_;
-
     # All strings in Python are Unicode already, so we'll need to do this
     # encoding step only for Perl
     if ( ref( $content ) eq ref( {} ) )
@@ -151,13 +144,25 @@ sub set_content_utf8($$)
         my $post_items = [];
         for my $key ( keys( %{ $content } ) )
         {
-            my $enc_key = uri_escape( encode_utf8( $key ) );
+            my $enc_key = $key;
+            if ( Encode::is_utf8( $enc_key ) ) {
+                $enc_key = encode_utf8( $enc_key );
+            }
+
+            $enc_key = uri_escape( $enc_key );
+
             my $data    = $content->{ $key };
             next unless ( $data );
             $data = [ $data ] unless ( ref( $data ) eq ref( [] ) );
             for my $datum ( @{ $data } )
             {
-                my $enc_datum = uri_escape( encode_utf8( $datum ) );
+                my $enc_datum = $datum;
+                if ( Encode::is_utf8( $enc_datum ) ) {
+                    $enc_datum = encode_utf8( $enc_datum );
+                }
+
+                $enc_datum = uri_escape( $enc_datum );
+
                 push( @{ $post_items }, "$enc_key=$enc_datum" );
             }
         }
@@ -166,7 +171,10 @@ sub set_content_utf8($$)
     }
     else
     {
-        $content = encode_utf8( $content );
+        if ( Encode::is_utf8( $content ) ) {
+            $content = encode_utf8( $content );
+        }
+
     }
 
     $self->{ _request }->set_content( $content );

--- a/apps/extract-article-from-page/bin/extract_article_from_page_http_server.py
+++ b/apps/extract-article-from-page/bin/extract_article_from_page_http_server.py
@@ -51,7 +51,7 @@ class ServerHandler(BaseHTTPRequestHandler):
         encoded_json_response = json_response.encode("UTF-8", errors="replace")
 
         self.send_response(status)
-        self.send_header("Content-Type", "application/json; encoding=UTF-8")
+        self.send_header("Content-Type", "application/json; charset=UTF-8")
         self.send_header("Content-Length", len(encoded_json_response))
         self.end_headers()
 

--- a/apps/import-solr-data/src/perl/MediaWords/Solr/Dump.pm
+++ b/apps/import-solr-data/src/perl/MediaWords/Solr/Dump.pm
@@ -283,7 +283,7 @@ sub _import_stories($)
     my ( $import_url, $import_params ) = _get_import_url_params();
 
     DEBUG "importing " . scalar( @{ $json->{ stories_ids } } ) . " stories into solr ...";
-    eval { MediaWords::Solr::Request::solr_request( $import_url, $import_params, $json->{ json }, 'application/json' ); };
+    eval { MediaWords::Solr::Request::solr_request( $import_url, $import_params, $json->{ json }, 'application/json; charset=utf-8' ); };
     die( "error importing to solr: $@" ) if ( $@ );
 
     TRACE( "committing solr index changes ..." );

--- a/apps/import-solr-data/tests/perl/MediaWords/Solr/Dump-no-utf8.t
+++ b/apps/import-solr-data/tests/perl/MediaWords/Solr/Dump-no-utf8.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+
+# No "use utf8;" here
+
+use Modern::Perl '2015';
+use MediaWords::CommonLibs;
+
+use Test::More;
+
+use MediaWords::DB;
+use MediaWords::Test::DB::Create;
+use MediaWords::Test::Solr;
+
+sub test_import_utf8($)
+{
+    my ( $db ) = @_;
+
+    my $test_medium = MediaWords::Test::DB::Create::create_test_medium( $db, 'test' );
+    my $test_feed = MediaWords::Test::DB::Create::create_test_feed( $db, 'test', $test_medium );
+
+    my $test_story = $db->create( 'stories', {
+        'media_id' => $test_medium->{ 'media_id' },
+        'url' => 'https://www.example.com/azuolas_berzas_ir_liepa.html',
+        'guid' => 'https://www.example.com/azuolas_berzas_ir_liepa.html',
+        'title' => 'ąžuolas',
+        'description' => '',
+        'publish_date' => '2020-02-05 14:06:00',
+        'collect_date' => '2020-02-05 18:18:47.271006',
+        'full_text_rss' => 'f',
+        'language' => 'lt',
+    } );
+
+    $db->create( 'feeds_stories_map', {
+        'feeds_id' => $test_feed->{ 'feeds_id' },
+        'stories_id' => $test_story->{ 'stories_id' },
+    });
+
+    $test_story->{ 'content' } = 'beržas';
+
+    $test_story = MediaWords::Test::DB::Create::add_content_to_test_story( $db, $test_story, $test_feed );
+
+    MediaWords::Test::Solr::setup_test_index( $db );
+
+    {
+        my $num_solr_stories = MediaWords::Solr::get_num_found( $db, { 'q' => 'title:ąžuolas' } );
+        ok( $num_solr_stories > 0, "UTF-8 stories were found by title" );
+    }
+
+    {
+        my $num_solr_stories = MediaWords::Solr::get_num_found( $db, { 'q' => 'text:beržas' } );
+        ok( $num_solr_stories > 0, "UTF-8 stories were found by text" );
+    }
+}
+
+sub main
+{
+    my $db = MediaWords::DB::connect_to_db();
+
+    test_import_utf8( $db );
+
+    done_testing();
+}
+
+main();

--- a/apps/import-solr-data/tests/perl/MediaWords/Solr/Dump-utf8.t
+++ b/apps/import-solr-data/tests/perl/MediaWords/Solr/Dump-utf8.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+
+use utf8;
+
+use Modern::Perl '2015';
+use MediaWords::CommonLibs;
+
+use Test::More;
+
+use MediaWords::DB;
+use MediaWords::Test::DB::Create;
+use MediaWords::Test::Solr;
+
+sub test_import_utf8($)
+{
+    my ( $db ) = @_;
+
+    my $test_medium = MediaWords::Test::DB::Create::create_test_medium( $db, 'test' );
+    my $test_feed = MediaWords::Test::DB::Create::create_test_feed( $db, 'test', $test_medium );
+
+    my $test_story = $db->create( 'stories', {
+        'media_id' => $test_medium->{ 'media_id' },
+        'url' => 'https://www.example.com/azuolas_berzas_ir_liepa.html',
+        'guid' => 'https://www.example.com/azuolas_berzas_ir_liepa.html',
+        'title' => 'ąžuolas',
+        'description' => '',
+        'publish_date' => '2020-02-05 14:06:00',
+        'collect_date' => '2020-02-05 18:18:47.271006',
+        'full_text_rss' => 'f',
+        'language' => 'lt',
+    } );
+
+    $db->create( 'feeds_stories_map', {
+        'feeds_id' => $test_feed->{ 'feeds_id' },
+        'stories_id' => $test_story->{ 'stories_id' },
+    });
+
+    $test_story->{ 'content' } = 'beržas';
+
+    $test_story = MediaWords::Test::DB::Create::add_content_to_test_story( $db, $test_story, $test_feed );
+
+    MediaWords::Test::Solr::setup_test_index( $db );
+
+    {
+        my $num_solr_stories = MediaWords::Solr::get_num_found( $db, { 'q' => 'title:ąžuolas' } );
+        ok( $num_solr_stories > 0, "UTF-8 stories were found by title" );
+    }
+
+    {
+        my $num_solr_stories = MediaWords::Solr::get_num_found( $db, { 'q' => 'text:beržas' } );
+        ok( $num_solr_stories > 0, "UTF-8 stories were found by text" );
+    }
+}
+
+sub main
+{
+    my $db = MediaWords::DB::connect_to_db();
+
+    test_import_utf8( $db );
+
+    done_testing();
+}
+
+main();

--- a/apps/topics-mine/src/python/topics_mine/posts/pushshift_reddit.py
+++ b/apps/topics-mine/src/python/topics_mine/posts/pushshift_reddit.py
@@ -103,7 +103,7 @@ class PushshiftRedditPostFetcher(AbstractPostFetcher):
         '''Pushshift API method to request data from Pushshift API'''
 
         headers = {'user-agent': 'mediacloud',
-                'content-type': 'application/json'}
+                'content-type': 'application/json; charset=UTF-8'}
         url = 'https://mediacloud.pushshift.io/rs/_search'
         r = requests.get(url, headers=headers, data=json.dumps(es_query))
 

--- a/apps/webapp-api/src/perl/MediaWords/Test/API.pm
+++ b/apps/webapp-api/src/perl/MediaWords/Test/API.pm
@@ -125,7 +125,7 @@ sub test_data_request($$$;$)
     my $json = MediaWords::Util::ParseJSON::encode_json( $data );
 
     my $request = HTTP::Request->new( $method, $url );
-    $request->header( 'Content-Type' => 'application/json' );
+    $request->header( 'Content-Type' => 'application/json; charset=UTF-8' );
     $request->content( $json );
 
     my $label = "method=$method URL=$url data=$json expect_error=$expect_error";


### PR DESCRIPTION
Hey Hal,

Another year, another "we've been importing garbled UTF-8 content into Solr, and no one noticed for quite some time" bug!

Research team reported that Hindi language queries didn't seem to work here:

https://github.com/mitmedialab/MediaCloud-Web-Tools/issues/1731#issuecomment-583146920

I looked into it, and turns out that a lot of Hindi and other UTF-8 text was garbled (double-encoded) in Solr.

Here's the proposed fix: in `set_content()`, try to identify whether Perl already thinks that scalars are in UTF-8, and encode them accordingly. Added a few UTF-8 tests as well, plus verified that stuff gets imported into Solr with the right encoding manually.

After deploying this, we'll need to reimport a bunch of stories, but it's hard to measure the impact of the bug - in the linked issue, it seems that some stories stopped coming in at around October or November, so maybe this happened due to me containerizing things? Or could those "other" stories be something that we've imported into Solr through some other means? I'm not sure.
