### PR TITLE
Dev run py exit code

### DIFF
--- a/dev/run.py
+++ b/dev/run.py
@@ -216,8 +216,7 @@ if __name__ == '__main__':
 
         for command_ in commands_:
             try:
-                if subprocess.call(command_):
-                    print("run.py subprocess exited with an error.")
+                subprocess.check_call(command_)
             except subprocess.CalledProcessError as ex_:
                 last_exception = ex_
 

--- a/dev/run.py
+++ b/dev/run.py
@@ -20,6 +20,7 @@ This script can print the commands that are going to be run instead of running t
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import List
 
@@ -211,14 +212,14 @@ if __name__ == '__main__':
 
     else:
 
-        # If command in "docker-compose run" fails, we'll store its exception here to later throw back to the user
-        last_exception = None
+        # If command in "docker-compose run" fails, we'll store its exit code here to later throw back to the user
+        last_non_zero_exit_code = 0
 
         for command_ in commands_:
-            try:
-                subprocess.check_call(command_)
-            except subprocess.CalledProcessError as ex_:
-                last_exception = ex_
+            exit_code = subprocess.call(command_)
+            if exit_code:
+                last_non_zero_exit_code = exit_code
 
-        if last_exception:
-            raise last_exception
+        if last_non_zero_exit_code:
+            sys.stderr.write("Subprocess returned non-zero exit status {}.\n".format(last_non_zero_exit_code))
+            sys.exit(last_non_zero_exit_code)


### PR DESCRIPTION
Hey Hal,

I was wondering why all of our tests suddenly started passing, and found out that you've changed `run.py`'s behavior so I had to fix it up a bit.

As you know, we use `run.py` for running both arbitrary commands (e.g. `bash`) and all of our unit tests in their respective isolated environments (as defined in every app's `docker-compose.tests.yml`).

To do its job, `run.py` runs the following commands in sequence:

1) `docker-compose run <service_name> <command>` - starts all of the services defined in `docker-compose.tests.yml`
2) `docker-compose down` - stops all of the services from the configuration and does some cleanup

The first command in this sequence, `docker-compose run`, might sometimes fail, e.g. if the command is running a test which fails an assertion. If the command fails, `run.py` *still* must run `docker-compose down` in order to shut down all of the services in the Compose configuration and clean up all the volumes; otherwise, subsequent runs of the same `run.py` command might lead to Docker reusing the previously created containers and volumes. In case of a unit test being run in such a setup, it might lead to unexpected results.

To achieve this, `run.py` ignored each `docker-compose` command's result and continued with the next command. However, the important bit in that script was that it kept note of the exception that has last occurred, and after running all of the commands threw the exception (if any) back to the caller so that the caller would get a chance to find out whether or not the `docker-compose run` command (e.g. a test that was run) was successful.

This is why `subprocess.call()` + printing an error message instead of `check_call()` didn't cut it - `call()` doesn't raise any exceptions that could be caught and remembered by `run.py` to be later thrown to `run.py` script's caller. In turn, `run.py` exited with a zero exit code, and our CI thought that each and every test passed with flying colors :)

I've modified `run.py` to track the "last non-zero exit code" instead of an exception while running `docker-compose` commands. Now, it will both be terse when reporting an error and return the correct exit code back to the caller.

Sorry for writing yet another novel on Docker and the operation of our helper scripts, just wanted to give you a heads-up on how it's expected to work (and for this PR to be useful for future reference).

This reverts commit 40c1350.