### PR TITLE
Ignore "tuple <...> was already moved to another partition" errors

### DIFF
--- a/apps/crawler-fetcher/src/python/crawler_fetcher/engine.py
+++ b/apps/crawler-fetcher/src/python/crawler_fetcher/engine.py
@@ -81,13 +81,19 @@ def _fetch_and_handle_download(db: DatabaseHandler, download: dict, handler: Abs
     response = handler.fetch_download(db=db, download=download)
     fetch_timer.stop()
 
-    store_timer = Timer('store').start()
-    try:
-        handler.store_response(db=db, download=download, response=response)
-    except Exception as ex:
-        log.error(f"Error in handle_response() for downloads_id {downloads_id} {url}: {ex}")
-        raise ex
-    store_timer.stop()
+    if response:
+
+        store_timer = Timer('store').start()
+        try:
+            handler.store_response(db=db, download=download, response=response)
+        except Exception as ex:
+            log.error(f"Error in handle_response() for downloads_id {downloads_id} {url}: {ex}")
+            raise ex
+        store_timer.stop()
+
+    else:
+
+        log.warning(f"Response for download {downloads_id} is None")
 
     log.info(f"Fetch done: {downloads_id} {url}")
 

--- a/apps/crawler-fetcher/src/python/crawler_fetcher/handler.py
+++ b/apps/crawler-fetcher/src/python/crawler_fetcher/handler.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Optional
 
 from mediawords.db import DatabaseHandler
 from mediawords.util.log import create_logger
@@ -11,7 +12,7 @@ class AbstractDownloadHandler(object, metaclass=abc.ABCMeta):
     """Abstract download handler."""
 
     @abc.abstractmethod
-    def fetch_download(self, db: DatabaseHandler, download: dict) -> Response:
+    def fetch_download(self, db: DatabaseHandler, download: dict) -> Optional[Response]:
         """Fetch the download and return the response.
 
         In addition to the basic HTTP request with the user agent options supplied by UserAgent() object, the
@@ -21,6 +22,9 @@ class AbstractDownloadHandler(object, metaclass=abc.ABCMeta):
         * Follow <meta /> refresh redirects in the response content;
         * Add domain specific HTTP auth specified in configuration;
         * Implement a very limited amount of site specific fixes.
+
+        Return Response if the download had to be fetched and was, in fact, fetched; or return None if the download
+        shouldn't / couldn't be fetched for whatever reason but no error is to be reported.
         """
         raise NotImplemented("Abstract method.")
 

--- a/apps/crawler-fetcher/src/python/crawler_fetcher/handlers/default/fetch_mixin.py
+++ b/apps/crawler-fetcher/src/python/crawler_fetcher/handlers/default/fetch_mixin.py
@@ -1,20 +1,25 @@
 import abc
+from typing import Optional
 
-from crawler_fetcher.exceptions import McCrawlerFetcherSoftError
 from mediawords.db import DatabaseHandler
+from mediawords.db.exceptions.handler import McTupleAlreadyMovedError
+from mediawords.util.log import create_logger
 from mediawords.util.perl import decode_object_from_bytes_if_needed
 from mediawords.util.sql import sql_now
 from mediawords.util.url import is_http_url
 from mediawords.util.web.user_agent import Response, UserAgent
 
 from crawler_fetcher.handler import AbstractDownloadHandler
+from crawler_fetcher.exceptions import McCrawlerFetcherSoftError
+
+log = create_logger(__name__)
 
 
 class DefaultFetchMixin(AbstractDownloadHandler, metaclass=abc.ABCMeta):
     """Mix-in to be used by download handlers which fetch the download using a simple UserAgent().get()."""
 
-    @classmethod
-    def _download_url(cls, download: dict) -> str:
+    # noinspection PyMethodMayBeStatic
+    def _download_url(self, download: dict) -> str:
         """
         Given a download dict, return an URL that should bet fetched for the download.
 
@@ -23,7 +28,7 @@ class DefaultFetchMixin(AbstractDownloadHandler, metaclass=abc.ABCMeta):
         """
         return download['url']
 
-    def fetch_download(self, db: DatabaseHandler, download: dict) -> Response:
+    def fetch_download(self, db: DatabaseHandler, download: dict) -> Optional[Response]:
         download = decode_object_from_bytes_if_needed(download)
 
         url = self._download_url(download=download)
@@ -33,7 +38,20 @@ class DefaultFetchMixin(AbstractDownloadHandler, metaclass=abc.ABCMeta):
         download['download_time'] = sql_now()
         download['state'] = 'fetching'
 
-        db.update_by_id(table='downloads', object_id=download['downloads_id'], update_hash=download)
+        try:
+            db.update_by_id(table='downloads', object_id=download['downloads_id'], update_hash=download)
+        except McTupleAlreadyMovedError as ex:
+            # Some attempts to set the download's row to "fetching" fail with:
+            #
+            #   "tuple to be locked was already moved to another partition due to concurrent update"
+            #
+            # If that happens, we assume that some other fetcher instance somehow got to the download first and do
+            # nothing
+            log.warning(f"Some other fetcher got to download {download['downloads_id']} first: {ex}")
+            return None
+        except Exception as ex:
+            # Raise further on misc. errors
+            raise ex
 
         ua = UserAgent()
         response = ua.get_follow_http_html_redirects(url)

--- a/apps/crawler-fetcher/tests/python/setup_handler_test.py
+++ b/apps/crawler-fetcher/tests/python/setup_handler_test.py
@@ -45,6 +45,8 @@ class TestDownloadHandler(TestCase, metaclass=abc.ABCMeta):
         handler = handler_for_download(db=self.db, download=download)
 
         response = handler.fetch_download(db=self.db, download=download)
+        assert response
+
         handler.store_response(db=self.db, download=download, response=response)
 
         download = self.db.find_by_id(table='downloads', object_id=downloads_id)

--- a/apps/crawler-fetcher/tests/python/setup_univision_test.py
+++ b/apps/crawler-fetcher/tests/python/setup_univision_test.py
@@ -148,6 +148,8 @@ class AbstractUnivisionTest(object, metaclass=abc.ABCMeta):
         handler = DownloadFeedUnivisionHandler(crawler_config=self._mock_crawler_config())
 
         response = handler.fetch_download(db=self.db, download=download)
+        assert response
+
         handler.store_response(db=self.db, download=download, response=response)
 
         download = self.db.find_by_id(table='downloads', object_id=download['downloads_id'])


### PR DESCRIPTION
If PostgreSQL throws the "tuple to be locked was already moved" error:

    tuple to be locked was already moved to another partition due to concurrent update

skip the download silently as we're assuming that some other
crawler-fetcher instance is currently fetching the very same download.

Fixes #669 (hopefully).

@hroberts, could you take a quick look?
