### PR TITLE
Stop Celery worker on exit(1)

### DIFF
--- a/apps/common/src/python/mediawords/job/__init__.py
+++ b/apps/common/src/python/mediawords/job/__init__.py
@@ -112,6 +112,9 @@ class JobBroker(object):
 
         self.__app.conf.broker_heartbeat = 0
 
+        # Acknowledge tasks after they get run, not before
+        self.__app.conf.task_acks_late = 1
+
         # https://tech.labs.oliverwyman.com/blog/2015/04/30/making-celery-play-nice-with-rabbitmq-and-bigwig/
         self.__app.conf.broker_transport_options = {'confirm_publish': True}
 

--- a/apps/common/src/python/mediawords/util/process.py
+++ b/apps/common/src/python/mediawords/util/process.py
@@ -1,4 +1,7 @@
 import os
+import signal
+
+import psutil
 
 from mediawords.util.log import create_logger
 from mediawords.util.perl import decode_object_from_bytes_if_needed
@@ -19,6 +22,21 @@ def fatal_error(message: str) -> None:
     message = decode_object_from_bytes_if_needed(message)
 
     log.error(message)
+
+    # If a Celery worker calls fatal_error(), it doesn't manage to kill the parent process because Celery forks new
+    # processes to run the actual job. So, find the parent process and send it a signal too for it to shut down.
+    parent_pid = os.getppid()
+    for proc in psutil.process_iter():
+        if proc.pid == parent_pid:
+            parent_command = proc.cmdline()
+            if 'python3' in parent_command[0].lower():
+                parent_group_id = os.getpgid(parent_pid)
+
+                log.warning(f"Killing parent PID {parent_pid}, group {parent_group_id} ({str(parent_command)}) too")
+
+                # Kill the whole group; also, go straight for SIGKILL as "acks_late" is set so unfinished jobs should
+                # get restarted properly
+                os.killpg(parent_group_id, signal.SIGKILL)
 
     # noinspection PyProtectedMember
     os._exit(1)

--- a/apps/common/src/requirements.txt
+++ b/apps/common/src/requirements.txt
@@ -61,6 +61,9 @@ nltk==3.4.5
 # PostgreSQL access
 psycopg2-binary==2.7.6.1
 
+# Process information
+psutil==5.7.0
+
 # Snowball stemmer (NLTK's implementation doesn't support Turkish)
 PyStemmer==1.3.0
 

--- a/apps/common/tests/python/mediawords/job/failing_worker.py
+++ b/apps/common/tests/python/mediawords/job/failing_worker.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+"""
+Worker that fails right away.
+"""
+
+from mediawords.job import JobBroker
+from mediawords.util.log import create_logger
+from mediawords.util.process import fatal_error
+
+log = create_logger(__name__)
+
+
+def run_failing_worker() -> None:
+    fatal_error(f"Failing worker.")
+
+
+if __name__ == '__main__':
+    app = JobBroker(queue_name='MediaWords::Job::FailingWorker')
+    app.start_worker(handler=run_failing_worker)

--- a/apps/common/tests/python/mediawords/job/test_worker_fatal_error.py
+++ b/apps/common/tests/python/mediawords/job/test_worker_fatal_error.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import time
+
+from mediawords.job import JobBroker
+from mediawords.util.log import create_logger
+
+log = create_logger(__name__)
+
+
+def test_worker_fatal_error():
+    worker_path = '/opt/mediacloud/tests/python/mediawords/job/failing_worker.py'
+    assert os.path.isfile(worker_path), f"Worker '{worker_path}' exists."
+    assert os.access(worker_path, os.X_OK), f"Worker '{worker_path}' is executable."
+
+    worker_process = subprocess.Popen([worker_path])
+    assert worker_process.poll() is None, "Worker process is still running."
+
+    JobBroker(queue_name='MediaWords::Job::FailingWorker').add_to_queue()
+
+    return_code = None
+    for retry in range(10):
+        log.info(f"Waiting for the process to stop (retry {retry})...")
+        return_code = worker_process.poll()
+        if return_code is not None:
+            log.info(f"Process stopped with return code {return_code}")
+            break
+        time.sleep(1)
+
+    assert return_code is not None, "Process has managed to stop."
+    assert return_code != 0, f"Process returned non-zero exit code {return_code}."


### PR DESCRIPTION
So, it turns out that Celery workers weren't stopping when the function that did the actual work called `fatal_error()` (`sys._exit(1)`). Instead, the worker was able to catch the error (as the work itself was being done in the fork) and continue along with other jobs, potentially failing all of them as well.

So, in this PR the `fatal_error()` helper tries to kill the parent PID in addition to the current process, provided that the parent PID is a `python` binary. Nasty workaround but I've found no way to configure Celery for it to stop when we need it to stop.