### PR TITLE
Run all containers with init

### DIFF
--- a/apps/cliff-fetch-annotation/docker-compose.tests.yml
+++ b/apps/cliff-fetch-annotation/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cliff-fetch-annotation:
         image: dockermediacloud/cliff-fetch-annotation:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -38,6 +40,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cliff-update-story-tags/docker-compose.tests.yml
+++ b/apps/cliff-update-story-tags/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cliff-update-story-tags:
         image: dockermediacloud/cliff-update-story-tags:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_CLIFF_VERSION_TAG: "cliff_clavin_v2.6.0"
@@ -31,6 +32,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -43,6 +45,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/common/docker-compose.tests.yml
+++ b/apps/common/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     common:
         image: dockermediacloud/common:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_DOWNLOADS_AMAZON_S3_ACCESS_KEY_ID: "${MC_DOWNLOADS_AMAZON_S3_ACCESS_KEY_ID}"
@@ -26,6 +27,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -42,6 +44,7 @@ services:
 
     import-solr-data-for-testing:
         image: dockermediacloud/import-solr-data-for-testing:latest
+        init: true
         environment:
             MC_SOLR_IMPORT_MAX_QUEUED_STORIES: 100000
         stop_signal: SIGKILL
@@ -64,6 +67,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -76,6 +80,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -92,6 +97,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -109,6 +115,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181
@@ -124,6 +131,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/common/tests/python/mediawords/job/failing_worker.py
+++ b/apps/common/tests/python/mediawords/job/failing_worker.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 """
-Worker that fails right away.
+Worker that fails pretty much right away.
 """
+
+import subprocess
+import time
 
 from mediawords.job import JobBroker
 from mediawords.util.log import create_logger
@@ -12,6 +15,13 @@ log = create_logger(__name__)
 
 
 def run_failing_worker() -> None:
+    # Start some background processes to see if they get killed properly
+    # noinspection PyUnusedLocal
+    bg_process_1 = subprocess.Popen(["sleep", "30"])
+    # noinspection PyUnusedLocal
+    bg_process_2 = subprocess.Popen(["sleep", "30"])
+    time.sleep(0.5)
+
     fatal_error(f"Failing worker.")
 
 

--- a/apps/crawler-ap/docker-compose.tests.yml
+++ b/apps/crawler-ap/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     crawler-ap:
         image: dockermediacloud/crawler-ap:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             # Tests will set their own dummy AP API key
@@ -30,6 +31,7 @@ services:
 
     extract-and-vector:
         image: dockermediacloud/extract-and-vector:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -49,6 +51,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -65,6 +68,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -77,6 +81,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -93,6 +98,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/crawler-fetcher/docker-compose.tests.yml
+++ b/apps/crawler-fetcher/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     crawler-fetcher:
         image: dockermediacloud/crawler-fetcher:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_UNIVISION_CLIENT_ID: "${MC_UNIVISION_CLIENT_ID}"
@@ -30,6 +31,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -42,6 +44,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -58,6 +61,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/crawler-provider/docker-compose.tests.yml
+++ b/apps/crawler-provider/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     crawler-provider:
         image: dockermediacloud/crawler-provider:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -23,6 +24,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -35,6 +37,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/create-missing-partitions/docker-compose.tests.yml
+++ b/apps/create-missing-partitions/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     create-missing-partitions:
         image: dockermediacloud/create-missing-partitions:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -17,6 +18,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -29,6 +31,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cron-generate-daily-rss-dumps/docker-compose.tests.yml
+++ b/apps/cron-generate-daily-rss-dumps/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-generate-daily-rss-dumps:
         image: dockermediacloud/cron-generate-daily-rss-dumps:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -20,6 +21,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -32,6 +34,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cron-generate-media-health/docker-compose.tests.yml
+++ b/apps/cron-generate-media-health/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-generate-media-health:
         image: dockermediacloud/cron-generate-media-health:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -38,6 +40,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cron-generate-user-summary/docker-compose.tests.yml
+++ b/apps/cron-generate-user-summary/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-generate-user-summary:
         image: dockermediacloud/cron-generate-user-summary:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -20,6 +21,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -32,6 +34,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cron-print-long-running-job-states/docker-compose.tests.yml
+++ b/apps/cron-print-long-running-job-states/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-print-long-running-job-states:
         image: dockermediacloud/cron-print-long-running-job-states:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -20,6 +21,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -32,6 +34,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cron-refresh-stats/docker-compose.tests.yml
+++ b/apps/cron-refresh-stats/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-refresh-stats:
         image: dockermediacloud/cron-refresh-stats:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -20,6 +21,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -32,6 +34,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cron-rescrape-due-media/docker-compose.tests.yml
+++ b/apps/cron-rescrape-due-media/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-rescrape-due-media:
         image: dockermediacloud/cron-rescrape-due-media:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -21,6 +22,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -33,6 +35,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -49,6 +52,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/cron-rescraping-changes/docker-compose.tests.yml
+++ b/apps/cron-rescraping-changes/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-rescraping-changes:
         image: dockermediacloud/cron-rescraping-changes:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -20,6 +21,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -32,6 +34,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cron-set-media-primary-language/docker-compose.tests.yml
+++ b/apps/cron-set-media-primary-language/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-set-media-primary-language:
         image: dockermediacloud/cron-set-media-primary-language:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -38,6 +40,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/cron-set-media-subject-country/docker-compose.tests.yml
+++ b/apps/cron-set-media-subject-country/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     cron-set-media-subject-country:
         image: dockermediacloud/cron-set-media-subject-country:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -38,6 +40,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -185,6 +185,7 @@ x-podcast-google-cloud-configuration:    &podcast-google-cloud-configuration
 x-solr-shard_base:   &solr-shard_base
     image: dockermediacloud/solr-shard:release
     <<: *sysctl-defaults
+    init: true
     environment:
         # Shard count (every individual shard needs to know the total count)
         #
@@ -276,6 +277,7 @@ services:
     cliff-annotator:
         image: dockermediacloud/cliff-annotator:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         expose:
@@ -300,6 +302,7 @@ services:
     cliff-fetch-annotation:
         image: dockermediacloud/cliff-fetch-annotation:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -327,6 +330,7 @@ services:
     cliff-update-story-tags:
         image: dockermediacloud/cliff-update-story-tags:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -362,6 +366,7 @@ services:
     crawler-ap:
         image: dockermediacloud/crawler-ap:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -390,6 +395,7 @@ services:
     crawler-fetcher:
         image: dockermediacloud/crawler-fetcher:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -420,6 +426,7 @@ services:
     crawler-provider:
         image: dockermediacloud/crawler-provider:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -443,6 +450,7 @@ services:
     create-missing-partitions:
         image: dockermediacloud/create-missing-partitions:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -466,6 +474,7 @@ services:
     cron-generate-daily-rss-dumps:
         image: dockermediacloud/cron-generate-daily-rss-dumps:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -496,6 +505,7 @@ services:
     cron-generate-media-health:
         image: dockermediacloud/cron-generate-media-health:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -519,6 +529,7 @@ services:
     cron-generate-user-summary:
         image: dockermediacloud/cron-generate-user-summary:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -542,6 +553,7 @@ services:
     cron-print-long-running-job-states:
         image: dockermediacloud/cron-print-long-running-job-states:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -565,6 +577,7 @@ services:
     cron-refresh-stats:
         image: dockermediacloud/cron-refresh-stats:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -588,6 +601,7 @@ services:
     cron-rescrape-due-media:
         image: dockermediacloud/cron-rescrape-due-media:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -612,6 +626,7 @@ services:
     cron-rescraping-changes:
         image: dockermediacloud/cron-rescraping-changes:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -635,6 +650,7 @@ services:
     cron-set-media-primary-language:
         image: dockermediacloud/cron-set-media-primary-language:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -658,6 +674,7 @@ services:
     cron-set-media-subject-country:
         image: dockermediacloud/cron-set-media-subject-country:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -681,6 +698,7 @@ services:
     extract-and-vector:
         image: dockermediacloud/extract-and-vector:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -708,6 +726,7 @@ services:
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -734,6 +753,7 @@ services:
     facebook-fetch-story-stats:
         image: dockermediacloud/facebook-fetch-story-stats:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -769,6 +789,7 @@ services:
     import-solr-data:
         image: dockermediacloud/import-solr-data:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -796,6 +817,7 @@ services:
     import-stories-feedly:
         image: dockermediacloud/import-stories-feedly:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -820,6 +842,7 @@ services:
     mail-opendkim-server:
         image: dockermediacloud/mail-opendkim-server:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -850,6 +873,7 @@ services:
     mail-postfix-server:
         image: dockermediacloud/mail-postfix-server:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -935,6 +959,7 @@ services:
     munin-fastcgi-graph:
         image: dockermediacloud/munin-fastcgi-graph:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         expose:
@@ -966,6 +991,7 @@ services:
     munin-httpd:
         image: dockermediacloud/munin-httpd:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         expose:
@@ -1028,6 +1054,7 @@ services:
     nytlabels-annotator:
         image: dockermediacloud/nytlabels-annotator:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         expose:
@@ -1051,6 +1078,7 @@ services:
     nytlabels-fetch-annotation:
         image: dockermediacloud/nytlabels-fetch-annotation:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1078,6 +1106,7 @@ services:
     nytlabels-update-story-tags:
         image: dockermediacloud/nytlabels-update-story-tags:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1108,6 +1137,7 @@ services:
     podcast-fetch-episode:
         image: dockermediacloud/podcast-fetch-episode:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1143,6 +1173,7 @@ services:
     podcast-fetch-transcript:
         image: dockermediacloud/podcast-fetch-transcript:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1174,6 +1205,7 @@ services:
     podcast-poll-due-operations:
         image: dockermediacloud/podcast-poll-due-operations:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1204,6 +1236,7 @@ services:
     podcast-submit-operation:
         image: dockermediacloud/podcast-submit-operation:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1236,6 +1269,7 @@ services:
     postgresql-pgadmin:
         image: dockermediacloud/postgresql-pgadmin:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         depends_on:
@@ -1264,6 +1298,7 @@ services:
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         depends_on:
@@ -1287,6 +1322,7 @@ services:
     postgresql-server:
         image: dockermediacloud/postgresql-server:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         expose:
@@ -1316,6 +1352,7 @@ services:
     proxy-cron-certbot:
         image: dockermediacloud/proxy-cron-certbot:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1350,6 +1387,7 @@ services:
     proxy-httpd:
         image: dockermediacloud/proxy-httpd:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         ports:
@@ -1384,6 +1422,7 @@ services:
     purge-object-caches:
         image: dockermediacloud/purge-object-caches:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1445,6 +1484,7 @@ services:
     rabbitmq-server-webapp-proxy:
         image: dockermediacloud/rabbitmq-server-webapp-proxy:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         depends_on:
@@ -1471,6 +1511,7 @@ services:
     rescrape-media:
         image: dockermediacloud/rescrape-media:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1497,6 +1538,7 @@ services:
     sitemap-fetch-media-pages:
         image: dockermediacloud/sitemap-fetch-media-pages:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1743,6 +1785,7 @@ services:
     solr-shard-webapp-proxy:
         image: dockermediacloud/solr-shard-webapp-proxy:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         depends_on:
@@ -1769,6 +1812,7 @@ services:
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         expose:
@@ -1792,6 +1836,7 @@ services:
     topics-extract-story-links:
         image: dockermediacloud/topics-extract-story-links:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1817,6 +1862,7 @@ services:
     topics-fetch-link:
         image: dockermediacloud/topics-fetch-link:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1842,6 +1888,7 @@ services:
     topics-fetch-twitter-urls:
         image: dockermediacloud/topics-fetch-twitter-urls:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1866,6 +1913,7 @@ services:
     topics-generate-retweeter-scores:
         image: dockermediacloud/topics-generate-retweeter-scores:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1890,6 +1938,7 @@ services:
     topics-mine:
         image: dockermediacloud/topics-mine:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1915,6 +1964,7 @@ services:
     topics-mine-public:
         image: dockermediacloud/topics-mine-public:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1940,6 +1990,7 @@ services:
     topics-snapshot:
         image: dockermediacloud/topics-snapshot:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1965,6 +2016,7 @@ services:
     webapp-api:
         image: dockermediacloud/webapp-api:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:
@@ -1991,6 +2043,7 @@ services:
     webapp-httpd:
         image: dockermediacloud/webapp-httpd:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         expose:
@@ -2019,6 +2072,7 @@ services:
     word2vec-generate-snapshot-model:
         image: dockermediacloud/word2vec-generate-snapshot-model:release
         <<: *sysctl-defaults
+        init: true
         networks:
             - default
         environment:

--- a/apps/docker-compose.portainer.yml
+++ b/apps/docker-compose.portainer.yml
@@ -27,6 +27,7 @@ services:
     # Web UI (run on a single server which has a label)
     portainer:
         image: portainer/portainer:1.23.1
+        init: true
         #
         # Hash the password:
         #
@@ -67,6 +68,7 @@ services:
     # Agent (run on every server)
     portainer-agent:
         image: portainer/agent:1.5.1
+        init: true
         networks:
             - portainer
         environment:

--- a/apps/dump-table/docker-compose.tests.yml
+++ b/apps/dump-table/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     dump-table:
         image: dockermediacloud/dump-table:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -17,6 +18,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -29,6 +31,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/export-tables-to-backup-crawler/docker-compose.tests.yml
+++ b/apps/export-tables-to-backup-crawler/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     export-tables-to-backup-crawler:
         image: dockermediacloud/export-tables-to-backup-crawler:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -23,6 +24,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -35,6 +37,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/extract-and-vector/docker-compose.tests.yml
+++ b/apps/extract-and-vector/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     extract-and-vector:
         image: dockermediacloud/extract-and-vector:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -42,6 +44,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -54,6 +57,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -70,6 +74,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/extract-article-from-page/docker-compose.tests.yml
+++ b/apps/extract-article-from-page/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080

--- a/apps/facebook-fetch-story-stats/docker-compose.tests.yml
+++ b/apps/facebook-fetch-story-stats/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     facebook-fetch-story-stats:
         image: dockermediacloud/facebook-fetch-story-stats:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_FACEBOOK_APP_ID: "${MC_FACEBOOK_APP_ID}"
@@ -27,6 +28,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -39,6 +41,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -55,6 +58,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/import-solr-data-for-testing/docker-compose.tests.yml
+++ b/apps/import-solr-data-for-testing/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     import-solr-data-for-testing:
         image: dockermediacloud/import-solr-data-for-testing:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_IMPORT_MAX_QUEUED_STORIES: 100000
@@ -27,6 +28,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -39,6 +41,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -55,6 +58,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -72,6 +76,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181
@@ -87,6 +92,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/import-solr-data/docker-compose.tests.yml
+++ b/apps/import-solr-data/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     import-solr-data:
         image: dockermediacloud/import-solr-data:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_IMPORT_MAX_QUEUED_STORIES: 100000
@@ -29,6 +30,7 @@ services:
 
     import-solr-data-for-testing:
         image: dockermediacloud/import-solr-data-for-testing:latest
+        init: true
         environment:
             MC_SOLR_IMPORT_MAX_QUEUED_STORIES: 100000
         stop_signal: SIGKILL
@@ -51,6 +53,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -63,6 +66,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -79,6 +83,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -96,6 +101,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181
@@ -111,6 +117,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/import-stories-feedly/docker-compose.tests.yml
+++ b/apps/import-stories-feedly/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     import-stories-feedly:
         image: dockermediacloud/import-stories-feedly:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -38,6 +40,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/import-stories-scrapehtml/docker-compose.tests.yml
+++ b/apps/import-stories-scrapehtml/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     import-stories-scrapehtml:
         image: dockermediacloud/import-stories-scrapehtml:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -38,6 +40,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -11,6 +11,7 @@ services:
     #
     mail-postfix-server:
         image: dockermediacloud/common:latest
+        init: true
         stop_signal: SIGKILL
         depends_on:
             - mail-postfix-server-actual
@@ -18,6 +19,7 @@ services:
     # Actual mail server, operating under "mail-postfix-server" alias
     mail-postfix-server-actual:
         image: dockermediacloud/mail-postfix-server:latest
+        init: true
         stop_signal: SIGKILL
         # "docker exec" into a container and run Postfix manually (/postfix.sh):
         command: sleep infinity
@@ -34,6 +36,7 @@ services:
 
     mail-opendkim-server:
         image: dockermediacloud/mail-opendkim-server:latest
+        init: true
         environment:
             MC_MAIL_OPENDKIM_DOMAIN: "testmediacloud.ml"
         expose:

--- a/apps/munin-cron/docker-compose.tests.yml
+++ b/apps/munin-cron/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     munin-cron:
         image: dockermediacloud/munin-cron:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -18,6 +19,7 @@ services:
 
     munin-node:
         image: dockermediacloud/munin-node:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -31,6 +33,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -43,6 +46,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -59,6 +63,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -76,6 +81,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181

--- a/apps/munin-httpd/docker-compose.tests.yml
+++ b/apps/munin-httpd/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     munin-httpd:
         image: dockermediacloud/munin-httpd:latest
+        init: true
         stop_signal: SIGKILL
         ports:
             # Expose to host for debugging
@@ -23,6 +24,7 @@ services:
 
     munin-fastcgi-graph:
         image: dockermediacloud/munin-fastcgi-graph:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 22334
@@ -32,6 +34,7 @@ services:
 
     munin-cron:
         image: dockermediacloud/munin-cron:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -46,6 +49,7 @@ services:
 
     munin-node:
         image: dockermediacloud/munin-node:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -59,6 +63,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -71,6 +76,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -87,6 +93,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -104,6 +111,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181

--- a/apps/munin-node/docker-compose.tests.yml
+++ b/apps/munin-node/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     munin-node:
         image: dockermediacloud/munin-node:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -17,6 +18,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -29,6 +31,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -45,6 +48,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -62,6 +66,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181

--- a/apps/nytlabels-fetch-annotation/docker-compose.tests.yml
+++ b/apps/nytlabels-fetch-annotation/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     nytlabels-fetch-annotation:
         image: dockermediacloud/nytlabels-fetch-annotation:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -38,6 +40,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/nytlabels-update-story-tags/docker-compose.tests.yml
+++ b/apps/nytlabels-update-story-tags/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     nytlabels-update-story-tags:
         image: dockermediacloud/nytlabels-update-story-tags:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_NYTLABELS_VERSION_TAG: "nyt_labeller_v1.0.0"
@@ -29,6 +30,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -41,6 +43,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/podcast-fetch-episode/docker-compose.tests.yml
+++ b/apps/podcast-fetch-episode/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     podcast-fetch-episode:
         image: dockermediacloud/podcast-fetch-episode:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_PODCAST_GC_AUTH_JSON_BASE64: "${MC_PODCAST_GC_AUTH_JSON_BASE64}"
@@ -30,6 +31,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -42,6 +44,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/podcast-fetch-transcript/docker-compose.tests.yml
+++ b/apps/podcast-fetch-transcript/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     podcast-fetch-transcript:
         image: dockermediacloud/podcast-fetch-transcript:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_PODCAST_GC_AUTH_JSON_BASE64: "${MC_PODCAST_GC_AUTH_JSON_BASE64}"
@@ -33,6 +34,7 @@ services:
 
     podcast-fetch-episode:
         image: dockermediacloud/podcast-fetch-episode:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_PODCAST_GC_AUTH_JSON_BASE64: "${MC_PODCAST_GC_AUTH_JSON_BASE64}"
@@ -54,6 +56,7 @@ services:
 
     podcast-submit-operation:
         image: dockermediacloud/podcast-submit-operation:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_PODCAST_GC_AUTH_JSON_BASE64: "${MC_PODCAST_GC_AUTH_JSON_BASE64}"
@@ -73,6 +76,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -85,6 +89,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -101,6 +106,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/podcast-poll-due-operations/docker-compose.tests.yml
+++ b/apps/podcast-poll-due-operations/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     podcast-poll-due-operations:
         image: dockermediacloud/podcast-poll-due-operations:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -24,6 +25,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -36,6 +38,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/podcast-submit-operation/docker-compose.tests.yml
+++ b/apps/podcast-submit-operation/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     podcast-submit-operation:
         image: dockermediacloud/podcast-submit-operation:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_PODCAST_GC_AUTH_JSON_BASE64: "${MC_PODCAST_GC_AUTH_JSON_BASE64}"
@@ -26,6 +27,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -38,6 +40,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/postgresql-pgadmin/docker-compose.tests.yml
+++ b/apps/postgresql-pgadmin/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     postgresql-pgadmin:
         image: dockermediacloud/postgresql-pgadmin:latest
+        init: true
         stop_signal: SIGKILL
         ports:
             # Expose to host for debugging
@@ -20,6 +21,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -32,6 +34,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/proxy-httpd/docker-compose.tests.yml
+++ b/apps/proxy-httpd/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     proxy-httpd:
         image: dockermediacloud/proxy-httpd:latest
+        init: true
         ports:
             # Expose to host for debugging
             - "80:8080"
@@ -23,6 +24,7 @@ services:
 
     proxy-cron-certbot:
         image: dockermediacloud/proxy-cron-certbot:latest
+        init: true
         environment:
             MC_PROXY_CERTBOT_DOMAIN: "mediacloud.org"
             MC_PROXY_CERTBOT_LETSENCRYPT_EMAIL: "linas@media.mit.edu"
@@ -40,6 +42,7 @@ services:
 
     webapp-httpd:
         image: dockermediacloud/webapp-httpd:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - "80"
@@ -56,6 +59,7 @@ services:
 
     webapp-api:
         image: dockermediacloud/webapp-api:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - "9090"

--- a/apps/purge-object-caches/docker-compose.tests.yml
+++ b/apps/purge-object-caches/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     purge-object-caches:
         image: dockermediacloud/purge-object-caches:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -17,6 +18,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -29,6 +31,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/rabbitmq-server-webapp-proxy/docker-compose.tests.yml
+++ b/apps/rabbitmq-server-webapp-proxy/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     rabbitmq-server-webapp-proxy:
         image: dockermediacloud/rabbitmq-server-webapp-proxy:latest
+        init: true
         stop_signal: SIGKILL
         ports:
             # Expose to host for debugging
@@ -20,6 +21,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/rescrape-media/docker-compose.tests.yml
+++ b/apps/rescrape-media/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     rescrape-media:
         image: dockermediacloud/rescrape-media:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -24,6 +25,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -36,6 +38,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -52,6 +55,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/solr-shard-webapp-proxy/docker-compose.tests.yml
+++ b/apps/solr-shard-webapp-proxy/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     solr-shard-webapp-proxy:
         image: dockermediacloud/solr-shard-webapp-proxy:latest
+        init: true
         networks:
             - default
         stop_signal: SIGKILL
@@ -22,6 +23,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         networks:
             - default
         stop_signal: SIGKILL
@@ -41,6 +43,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181

--- a/apps/solr-shard/docker-compose.tests.yml
+++ b/apps/solr-shard/docker-compose.tests.yml
@@ -15,6 +15,7 @@ version: "3.7"
 # Base service for Solr shard
 x-solr-shard_base:   &solr-shard_base
     image: dockermediacloud/solr-shard:latest
+    init: true
     stop_signal: SIGKILL
     environment:
         MC_SOLR_SHARD_COUNT: "4"
@@ -64,6 +65,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181

--- a/apps/tools/docker-compose.tests.yml
+++ b/apps/tools/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     tools:
         image: dockermediacloud/tools:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -19,6 +20,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -31,6 +33,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -47,6 +50,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -64,6 +68,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181
@@ -79,6 +84,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/topics-base/docker-compose.tests.yml
+++ b/apps/topics-base/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     topics-base:
         image: dockermediacloud/topics-base:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             # Tests call mock API endpoint and don't need API credentials
@@ -32,6 +33,7 @@ services:
 
     extract-and-vector:
         image: dockermediacloud/extract-and-vector:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -49,6 +51,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -65,6 +68,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -77,6 +81,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -93,6 +98,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/topics-extract-story-links/docker-compose.tests.yml
+++ b/apps/topics-extract-story-links/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     topics-extract-story-links:
         image: dockermediacloud/topics-extract-story-links:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -32,6 +33,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -48,6 +50,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -60,6 +63,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432

--- a/apps/topics-fetch-link/docker-compose.tests.yml
+++ b/apps/topics-fetch-link/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     topics-fetch-link:
         image: dockermediacloud/topics-fetch-link:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -32,6 +33,7 @@ services:
 
     extract-and-vector:
         image: dockermediacloud/extract-and-vector:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -49,6 +51,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -65,6 +68,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -77,6 +81,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -93,6 +98,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/topics-fetch-twitter-urls/docker-compose.tests.yml
+++ b/apps/topics-fetch-twitter-urls/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     topics-fetch-twitter-urls:
         image: dockermediacloud/topics-fetch-twitter-urls:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_TWITTER_CONSUMER_KEY: "${MC_TWITTER_CONSUMER_KEY}"
@@ -36,6 +37,7 @@ services:
 
     extract-and-vector:
         image: dockermediacloud/extract-and-vector:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -53,6 +55,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -69,6 +72,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -81,6 +85,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -97,6 +102,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/topics-generate-retweeter-scores/docker-compose.tests.yml
+++ b/apps/topics-generate-retweeter-scores/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     topics-generate-retweeter-scores:
         image: dockermediacloud/topics-generate-retweeter-scores:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -26,6 +27,7 @@ services:
 
     extract-and-vector:
         image: dockermediacloud/extract-and-vector:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -43,6 +45,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -59,6 +62,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -71,6 +75,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -87,6 +92,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/topics-mine/docker-compose.tests.yml
+++ b/apps/topics-mine/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     topics-mine:
         image: dockermediacloud/topics-mine:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_CRIMSON_HEXAGON_API_KEY: "${MC_CRIMSON_HEXAGON_API_KEY}"
@@ -49,6 +50,7 @@ services:
 
     extract-and-vector:
         image: dockermediacloud/extract-and-vector:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -66,6 +68,7 @@ services:
 
     extract-article-from-page:
         image: dockermediacloud/extract-article-from-page:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 8080
@@ -82,6 +85,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -94,6 +98,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -110,6 +115,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672
@@ -121,6 +127,7 @@ services:
 
     topics-fetch-link:
         image: dockermediacloud/topics-fetch-link:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -146,6 +153,7 @@ services:
 
     topics-extract-story-links:
         image: dockermediacloud/topics-extract-story-links:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind

--- a/apps/topics-snapshot/docker-compose.tests.yml
+++ b/apps/topics-snapshot/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     topics-snapshot:
         image: dockermediacloud/topics-snapshot:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_TOPICS_SNAPSHOT_MODEL_REPS: "0"
@@ -31,6 +32,7 @@ services:
 
     import-solr-data-for-testing:
         image: dockermediacloud/import-solr-data-for-testing:latest
+        init: true
         environment:
             MC_SOLR_IMPORT_MAX_QUEUED_STORIES: 100000
         stop_signal: SIGKILL
@@ -53,6 +55,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -65,6 +68,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -81,6 +85,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -98,6 +103,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181
@@ -113,6 +119,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672

--- a/apps/webapp-api/docker-compose.tests.yml
+++ b/apps/webapp-api/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     webapp-api:
         image: dockermediacloud/webapp-api:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -31,6 +32,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -43,6 +45,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -59,6 +62,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -76,6 +80,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181
@@ -91,6 +96,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672
@@ -102,6 +108,7 @@ services:
 
     rescrape-media:
         image: dockermediacloud/rescrape-media:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -119,6 +126,7 @@ services:
 
     word2vec-generate-snapshot-model:
         image: dockermediacloud/word2vec-generate-snapshot-model:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -135,6 +143,7 @@ services:
 
     topics-snapshot:
         image: dockermediacloud/topics-snapshot:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_TOPICS_SNAPSHOT_MODEL_REPS: "0"
@@ -159,6 +168,7 @@ services:
 
     import-solr-data-for-testing:
         image: dockermediacloud/import-solr-data-for-testing:latest
+        init: true
         environment:
             MC_SOLR_IMPORT_MAX_QUEUED_STORIES: 100000
         stop_signal: SIGKILL

--- a/apps/webapp-httpd/docker-compose.tests.yml
+++ b/apps/webapp-httpd/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     webapp-httpd:
         image: dockermediacloud/webapp-httpd:latest
+        init: true
         stop_signal: SIGKILL
         ports:
             # Expose to host for debugging
@@ -23,6 +24,7 @@ services:
 
     webapp-api:
         image: dockermediacloud/webapp-api:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - "9090"
@@ -52,6 +54,7 @@ services:
 
     cron-generate-daily-rss-dumps:
         image: dockermediacloud/cron-generate-daily-rss-dumps:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             # Shared with "webapp-httpd":
@@ -70,6 +73,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -82,6 +86,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432
@@ -98,6 +103,7 @@ services:
 
     solr-shard-01:
         image: dockermediacloud/solr-shard:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_SOLR_SHARD_COUNT: "1"
@@ -115,6 +121,7 @@ services:
 
     solr-zookeeper:
         image: dockermediacloud/solr-zookeeper:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 2181
@@ -130,6 +137,7 @@ services:
 
     rabbitmq-server:
         image: dockermediacloud/rabbitmq-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5672
@@ -141,6 +149,7 @@ services:
 
     rescrape-media:
         image: dockermediacloud/rescrape-media:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -158,6 +167,7 @@ services:
 
     word2vec-generate-snapshot-model:
         image: dockermediacloud/word2vec-generate-snapshot-model:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -174,6 +184,7 @@ services:
 
     topics-snapshot:
         image: dockermediacloud/topics-snapshot:latest
+        init: true
         stop_signal: SIGKILL
         environment:
             MC_TOPICS_SNAPSHOT_MODEL_REPS: "0"
@@ -198,6 +209,7 @@ services:
 
     import-solr-data-for-testing:
         image: dockermediacloud/import-solr-data-for-testing:latest
+        init: true
         environment:
             MC_SOLR_IMPORT_MAX_QUEUED_STORIES: 100000
         stop_signal: SIGKILL

--- a/apps/word2vec-generate-snapshot-model/docker-compose.tests.yml
+++ b/apps/word2vec-generate-snapshot-model/docker-compose.tests.yml
@@ -4,6 +4,7 @@ services:
 
     word2vec-generate-snapshot-model:
         image: dockermediacloud/word2vec-generate-snapshot-model:latest
+        init: true
         stop_signal: SIGKILL
         volumes:
             - type: bind
@@ -23,6 +24,7 @@ services:
 
     postgresql-pgbouncer:
         image: dockermediacloud/postgresql-pgbouncer:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 6432
@@ -35,6 +37,7 @@ services:
 
     postgresql-server:
         image: dockermediacloud/postgresql-server:latest
+        init: true
         stop_signal: SIGKILL
         expose:
             - 5432


### PR DESCRIPTION
Run all Docker containers with init enabled (`init: true`):

* Better handling of zombie processes.
* Better handling of children processes.
* Processes are now able to kill themselves if they so please (via `fatal_error()`).
