### PR TITLE
Make no_dedup_sentences the default for extract-and-vector

### DIFF
--- a/apps/common/src/python/mediawords/util/config/__init__.py
+++ b/apps/common/src/python/mediawords/util/config/__init__.py
@@ -46,6 +46,16 @@ def env_value(name: str, required: bool = True, allow_empty_string: bool = False
 
     return value
 
+def env_bool(name: str, default: bool = False) -> bool:
+    """
+    Retrieve boolean from environment variable; should be 0 or 1.
+
+    :param name: Environment variable name.
+    :param default: default value, if no value found.
+    """
+
+    value = os.environ.get(name, default)
+    return bool(int(value))
 
 def file_with_env_value(name: str, allow_empty_string: bool = False, encoded_with_base64: bool = False) -> str:
     """

--- a/apps/extract-and-vector/bin/extract_and_vector_worker.py
+++ b/apps/extract-and-vector/bin/extract_and_vector_worker.py
@@ -4,6 +4,7 @@ import time
 
 from mediawords.db import connect_to_db
 from mediawords.job import JobBroker
+from mediawords.util.config import env_bool
 from mediawords.util.log import create_logger
 from mediawords.util.perl import decode_object_from_bytes_if_needed
 from extract_and_vector.dbi.stories.extractor_arguments import PyExtractorArguments
@@ -69,8 +70,10 @@ def run_extract_and_vector(stories_id: int, use_cache: bool = False, use_existin
 
     log.info("Extracting story {}...".format(stories_id))
 
+    no_dedup_sentences = env_bool('MC_NO_DEDUP_SENTENCES', True)
     try:
-        extractor_args = PyExtractorArguments(use_cache=use_cache, use_existing=use_existing)
+        extractor_args = PyExtractorArguments(use_cache=use_cache, use_existing=use_existing,
+                                              no_dedup_sentences=no_dedup_sentences)
         extract_and_process_story(db=db, story=story, extractor_args=extractor_args)
 
     except Exception as ex:


### PR DESCRIPTION
can be overridden via MC_NO_DEDUP_SENTENCES env var

apps/common/src/python/mediawords/util/config/__init__.py: add env_bool function
apps/extract-and-vector/bin/extract_and_vector_worker.py: honor MC_NO_DEDUP_SENTENCES