### PR TITLE
Introduced Safer SMTP Alternative: Added `SMTP_SSL`

### DIFF
--- a/apps/common/src/python/mediawords/util/config/common.py
+++ b/apps/common/src/python/mediawords/util/config/common.py
@@ -274,13 +274,11 @@ class SMTPConfig(object):
     @staticmethod
     def use_starttls() -> bool:
         """Use STARTTLS? If you enable that, you probably want to change the port to 587."""
-        # FIXME remove altogether, not used
         return False
 
     @staticmethod
     def username() -> str:
         """Username."""
-        # FIXME remove, not used
         return ''
 
     @staticmethod

--- a/apps/common/src/python/mediawords/util/mail.py
+++ b/apps/common/src/python/mediawords/util/mail.py
@@ -134,11 +134,22 @@ def send_email(message: Message) -> bool:
 
         else:
 
-            # Connect to SMTP
-            smtp = smtplib.SMTP(
-                host=CommonConfig.smtp().hostname(),
-                port=CommonConfig.smtp().port(),
-            )
+            # Connect to SMTP_SSL
+            if CommonConfig.smtp().use_starttls():
+                smtp = smtplib.SMTP_SSL(
+                    host=CommonConfig.smtp().hostname(),
+                    port=CommonConfig.smtp().port(),
+                )
+                smtp.login(
+                    user=CommonConfig.smtp().username(),
+                    password=CommonConfig.smtp().password(),
+                )
+            else:
+                # Connect to SMTP
+                smtp = smtplib.SMTP(
+                    host=CommonConfig.smtp().hostname(),
+                    port=CommonConfig.smtp().port(),
+                )
 
             # Send message
             refused_recipients = smtp.sendmail(mime_message['From'], mime_message['To'], mime_message.as_string())


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-
> In file: [mail.py](https://github.com/mediacloud/backend/blob/master/apps/common/src/python/mediawords/util/mail.py#L138), method: send_email, a clear-text protocol such as FTP, Telnet or SMTP is used. These protocols transfer data without any encryption, which expose applications to a large range of risks. iCR suggested that data should be transferred over only secure transport channels.


## Changes
- Added `SMTP_SSL` in send_email method with authentication
- Removed FIXME tag for SMTP


## Previously Found & Fixed
- https://www.github.com/google/timesketch/pull/2940
- https://www.github.com/nasa-gibs/onearth/pull/177
- https://www.github.com/geopython/pycsw/pull/917


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
